### PR TITLE
Add Support For Multiple Jira Organisations

### DIFF
--- a/backend/controllers/projectManagementController.ts
+++ b/backend/controllers/projectManagementController.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { URLSearchParams } from 'url';
 import { fetchAndSaveJiraData } from '../jobs/jiraJob';
 import CourseModel from '../models/Course';
-import { getAccountId } from 'utils/auth';
+import { getAccountId } from '../utils/auth';
 import { getJiraBoardNamesByCourse } from 'services/projectManagementService';
 import { NotFoundError } from 'services/errors';
 

--- a/backend/controllers/projectManagementController.ts
+++ b/backend/controllers/projectManagementController.ts
@@ -69,13 +69,13 @@ export const callbackJiraAccount = async (req: Request, res: Response) => {
       .then(response => response.json())
       .then(async data => {
         // Extract the cloudId from the response
-        const cloudId = data[0].id; // Assuming the cloudId is in the first element of the response
+        const cloudIds = data.map((item: { id: string }) => item.id);
         await CourseModel.findOneAndUpdate(
           { _id: state },
           {
             jira: {
               isRegistered: true,
-              cloudId: cloudId,
+              cloudIds: cloudIds,
               accessToken: accessToken,
               refreshToken: refreshToken,
             },

--- a/backend/jobs/jiraJob.ts
+++ b/backend/jobs/jiraJob.ts
@@ -188,7 +188,9 @@ async function fetchIssues(
         if (storyPointsResponse.ok) {
           storyPoints = (await storyPointsResponse.json()).value;
         } else {
-          console.error(`Failed to fetch story points. Status: ${storyPointsResponse.status}`);
+          console.error(
+            `Failed to fetch story points. Status: ${storyPointsResponse.status}`
+          );
         }
 
         const jiraIssue: Omit<JiraIssue, '_id'> = {

--- a/backend/models/Course.ts
+++ b/backend/models/Course.ts
@@ -47,7 +47,7 @@ export const courseSchema = new Schema<Course>({
   gitHubOrgName: String,
   jira: {
     isRegistered: { type: Boolean, required: true, default: false },
-    cloudId: { type: String },
+    cloudIds: [{ type: String }],
     accessToken: { type: String },
     refreshToken: { type: String },
   },

--- a/multi-git-dashboard/src/components/views/ProjectManagementInfo.tsx
+++ b/multi-git-dashboard/src/components/views/ProjectManagementInfo.tsx
@@ -113,8 +113,8 @@ const ProjectManagementInfo: React.FC<ProjectManagementProps> = ({
             <Group style={{ marginBottom: '16px', marginTop: '16px' }}>
               <Button onClick={handleOAuthButtonClick}>
                 {jiraRegistrationStatus
-                  ? 'Reauthorize with Jira'
-                  : 'Authorize with Jira'}
+                  ? 'Authorize Another Jira Organization'
+                  : 'Authorize With Jira'}
               </Button>
             </Group>
           )}

--- a/shared/types/Course.ts
+++ b/shared/types/Course.ts
@@ -43,7 +43,7 @@ export interface Course {
   // end 'GitHubOrg' fields
   jira: {
     isRegistered: boolean;
-    cloudId: string;
+    cloudIds: string[];
     accessToken: string;
     refreshToken: string;
   };


### PR DESCRIPTION
## Description

- Registered Atlassian account to the course can now support more than 1 Jira organization

- CRISP will now pull all the boards from every organization approved based on all the cloudIds saved.

## Changes

- Modify schema to support multiple cloudIds for more than 1 Jira organization to be registered to each course.

## Screenshots (if applicable)

Include any relevant screenshots or GIFs that demonstrate your changes visually.

## Additional Notes

Include any additional comments or context.

Resolves #158 