### PR TITLE
Extend CRISP Functionalities For Public GitHub Repositories

### DIFF
--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -3,6 +3,7 @@ import { addAssessmentsToCourse } from '../services/assessmentService';
 import {
   addFacultyToCourse,
   addMilestoneToCourse,
+  addRepositoriesToCourse,
   addSprintToCourse,
   addStudentsToCourse,
   addTAsToCourse,
@@ -336,6 +337,24 @@ export const getRepositories = async (req: Request, res: Response) => {
     } else {
       console.error('Error fetching repositories:', error);
       res.status(500).json({ error: 'Failed to retrieve repositories' });
+    }
+  }
+};
+
+export const addRepositories = async (req: Request, res: Response) => {
+  const courseId = req.params.id;
+  const repositories = req.body.items;
+  try {
+    await addRepositoriesToCourse(courseId, repositories);
+    res
+      .status(200)
+      .json({ message: 'Repositories added to the course successfully' });
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      res.status(404).json({ error: error.message });
+    } else {
+      console.error('Error adding repositories:', error);
+      res.status(500).json({ error: 'Failed to add repositories' });
     }
   }
 };

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -367,18 +367,18 @@ export const updateRepository = async (req: Request, res: Response) => {
 
   try {
     await editRepository(id, Number(repositoryIndex), updateData);
-    res.status(200).json({ message: 'Repository edited successfully' });
+    res.status(200).json({ message: 'Repository updated successfully' });
   } catch (error) {
     if (error instanceof NotFoundError) {
       res.status(404).json({ error: error.message });
     } else {
       console.error('Error editing repository:', error);
-      res.status(500).json({ error: 'Failed to edit repository' });
+      res.status(500).json({ error: 'Failed to update repository' });
     }
   }
 };
 
-export const deleteRepository = async (req: Request, res: Response) => {
+export const removeRepository = async (req: Request, res: Response) => {
   const { id, repositoryIndex } = req.params;
   try {
     await removeRepositoryFromCourse(id, Number(repositoryIndex));

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -22,6 +22,7 @@ import {
   getTeamSetNamesFromCourse,
   getTeamSetsFromCourse,
   removeFacultyFromCourse,
+  removeRepositoryFromCourse,
   removeStudentsFromCourse,
   removeTAsFromCourse,
   updateCourseById,
@@ -355,6 +356,23 @@ export const addRepositories = async (req: Request, res: Response) => {
     } else {
       console.error('Error adding repositories:', error);
       res.status(500).json({ error: 'Failed to add repositories' });
+    }
+  }
+};
+
+export const deleteRepository = async (req: Request, res: Response) => {
+  const { id, repositoryIndex } = req.params;
+  try {
+    await removeRepositoryFromCourse(id, Number(repositoryIndex));
+    res
+      .status(200)
+      .json({ message: 'Repository removed from the course successfully' });
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      res.status(404).json({ error: error.message });
+    } else {
+      console.error('Error removing repository:', error);
+      res.status(500).json({ error: 'Failed to remove repository' });
     }
   }
 };

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -9,6 +9,7 @@ import {
   addTAsToCourse,
   createNewCourse,
   deleteCourseById,
+  editRepository,
   getAssessmentsFromCourse,
   getCourseById,
   getCourseCodeById,
@@ -356,6 +357,23 @@ export const addRepositories = async (req: Request, res: Response) => {
     } else {
       console.error('Error adding repositories:', error);
       res.status(500).json({ error: 'Failed to add repositories' });
+    }
+  }
+};
+
+export const updateRepository = async (req: Request, res: Response) => {
+  const { id, repositoryIndex } = req.params;
+  const updateData = req.body;
+
+  try {
+    await editRepository(id, Number(repositoryIndex), updateData);
+    res.status(200).json({ message: 'Repository edited successfully' });
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      res.status(404).json({ error: error.message });
+    } else {
+      console.error('Error editing repository:', error);
+      res.status(500).json({ error: 'Failed to edit repository' });
     }
   }
 };

--- a/backend/controllers/courseController.ts
+++ b/backend/controllers/courseController.ts
@@ -17,6 +17,7 @@ import {
   getCoursesForUser,
   getPeopleFromCourse,
   getProjectManagementBoardFromCourse,
+  getRepositoriesFromCourse,
   getTeamSetNamesFromCourse,
   getTeamSetsFromCourse,
   removeFacultyFromCourse,
@@ -319,6 +320,22 @@ export const getPeople = async (req: Request, res: Response) => {
     } else {
       console.error('Error fetching people:', error);
       res.status(500).json({ error: 'Failed to retrieve people' });
+    }
+  }
+};
+
+/*-------------------------------------Repositories-------------------------------------*/
+export const getRepositories = async (req: Request, res: Response) => {
+  const courseId = req.params.id;
+  try {
+    const repositories = await getRepositoriesFromCourse(courseId);
+    res.status(200).json(repositories);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      res.status(404).json({ error: error.message });
+    } else {
+      console.error('Error fetching repositories:', error);
+      res.status(500).json({ error: 'Failed to retrieve repositories' });
     }
   }
 };

--- a/backend/jobs/publicGithubJob.ts
+++ b/backend/jobs/publicGithubJob.ts
@@ -1,0 +1,388 @@
+import CourseModel from '@models/Course';
+import { Review, TeamContribution, TeamPR } from '@shared/types/TeamData';
+import cron from 'node-cron';
+import { Octokit } from 'octokit';
+import TeamData from '../models/TeamData';
+
+const fetchPublicRepoData = async () => {
+  const octokit = new Octokit(); // No need for GitHub App authentication for public repos
+
+  const courses = await CourseModel.find();
+
+  await Promise.all(
+    courses.map(async course => {
+      if (course && course.gitHubRepoLinks.length > 0) {
+        try {
+          // Call getPublicCourseData to process the course and repo data
+          await getPublicCourseData(octokit, course);
+        } catch (error) {
+          console.error(
+            `Error fetching repository data for ${course.name}:`,
+            error
+          );
+        }
+      }
+    })
+  );
+
+  console.log('fetchPublicRepoData job done');
+};
+
+const getPublicCourseData = async (octokit: Octokit, course: any) => {
+  if (!course.gitHubRepoLinks || course.gitHubRepoLinks.length === 0) return;
+
+  for (const repoUrl of course.gitHubRepoLinks) {
+    const urlParts = repoUrl.split('/');
+    const owner = urlParts[3]; // Get the 'owner' part of the URL
+    const repo = urlParts[4]; // Get the 'repo' part of the URL
+
+    try {
+      // Fetch repository data using public Octokit instance
+      const repoData = await octokit.rest.repos.get({
+        owner,
+        repo,
+      });
+
+      console.log('Repository Data:', repoData.data);
+
+      // Fetch branches or other details
+      const branches = await octokit.rest.repos.listBranches({
+        owner,
+        repo,
+      });
+
+      console.log('Branches:', branches.data);
+
+      const teamContributions: Record<string, TeamContribution> = {};
+
+      const [commits, issues, prs, contributors, milestones] =
+        await Promise.all([
+          fetchAllPagesWithBackoff(page =>
+            octokit.rest.repos.listCommits({
+              owner,
+              repo,
+              since: getFourMonthsAgo(),
+              per_page: 100,
+              page,
+            })
+          ),
+          fetchAllPagesWithBackoff(page =>
+            octokit.rest.issues.listForRepo({
+              owner,
+              repo,
+              since: getFourMonthsAgo(),
+              per_page: 100,
+              page,
+            })
+          ),
+          fetchAllPagesWithBackoff(page =>
+            octokit.rest.pulls.list({
+              owner,
+              repo,
+              since: getFourMonthsAgo(),
+              state: 'all',
+              per_page: 100,
+              page,
+            })
+          ),
+          fetchAllPagesWithBackoff(page =>
+            octokit.rest.repos.listContributors({
+              owner,
+              repo,
+              per_page: 100,
+              page,
+            })
+          ),
+          fetchAllPagesWithBackoff(page =>
+            octokit.rest.issues.listMilestones({
+              owner,
+              repo,
+              state: 'all',
+              per_page: 100,
+              page,
+            })
+          ),
+        ]);
+
+      let codeFrequencyStats: number[][] = [];
+      try {
+        codeFrequencyStats = await fetchCodeFrequencyStats(
+          octokit,
+          owner,
+          repo
+        );
+      } catch (err) {
+        console.error('Error fetching code frequency stats:', err);
+      }
+
+      const teamPRs: TeamPR[] = await Promise.all(
+        prs.map(async pr => {
+          const reviews = await fetchAllPagesWithBackoff(page =>
+            octokit.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+              page,
+            })
+          );
+
+          const reviewDetails: Review[] = await Promise.all(
+            reviews.map(async review => ({
+              id: review.id,
+              user: review.user?.login,
+              body: review.body,
+              state: review.state,
+              submittedAt: review.submitted_at,
+              comments: (
+                await fetchAllPagesWithBackoff(page =>
+                  octokit.rest.pulls.listReviewComments({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                    review_id: review.id,
+                    per_page: 100,
+                    page,
+                  })
+                )
+              ).map(comment => ({
+                id: comment.id,
+                body: comment.body,
+                user: comment.user.login,
+                createdAt: new Date(comment.created_at),
+              })),
+            }))
+          );
+
+          return {
+            id: pr.id,
+            title: pr.title,
+            user: pr.user?.login || '',
+            url: pr.html_url,
+            state: pr.state,
+            createdAt: new Date(pr.created_at),
+            updatedAt: new Date(pr.updated_at),
+            reviews: reviewDetails.map(review => ({
+              id: review.id,
+              body: review.body,
+              state: review.state,
+              submittedAt: review.submittedAt,
+              user: review.user,
+              comments: review.comments.map(comment => ({
+                id: comment.id,
+                body: comment.body,
+                user: comment.user,
+                createdAt: new Date(comment.createdAt),
+              })),
+            })),
+          };
+        })
+      );
+
+      // Process team contributions (same as the original code)
+      for (const contributor of contributors) {
+        if (!contributor.login) continue;
+
+        const contributorCommits = commits.filter(
+          commit => commit.author?.login === contributor.login
+        ).length;
+
+        const createdIssues = issues.filter(
+          issue => issue.user && issue.user.login === contributor.login
+        ).length;
+        const openIssues = issues.filter(
+          issue =>
+            issue.user &&
+            issue.user.login === contributor.login &&
+            issue.state === 'open'
+        ).length;
+        const closedIssues = issues.filter(
+          issue =>
+            issue.user &&
+            issue.user.login === contributor.login &&
+            issue.state === 'closed'
+        ).length;
+
+        const contributorPRs = prs.filter(
+          pr => pr.user && pr.user.login === contributor.login
+        ).length;
+
+        teamContributions[contributor.login] = {
+          commits: contributorCommits,
+          createdIssues: createdIssues,
+          openIssues: openIssues,
+          closedIssues: closedIssues,
+          pullRequests: contributorPRs,
+          codeReviews: 0,
+          comments: 0,
+        };
+      }
+
+      // Continue with team PR reviews and save data
+      for (const teamPR of teamPRs) {
+        for (const review of teamPR.reviews) {
+          if (!review.user || !(review.user in teamContributions)) continue;
+          teamContributions[review.user].codeReviews++;
+          teamContributions[review.user].comments += review.comments.length;
+        }
+      }
+
+      const teamData = {
+        gitHubOrgName: owner.toLowerCase(),
+        teamId: repoData.data.id,
+        repoName: repo,
+        commits: commits.length,
+        weeklyCommits: codeFrequencyStats,
+        issues: issues.length,
+        pullRequests: prs.length,
+        updatedIssues: issues.map(issue => issue.updated_at),
+        teamContributions,
+        teamPRs,
+        milestones: milestones,
+      };
+
+      console.log('Saving team data:', teamData);
+
+      await TeamData.findOneAndUpdate({ teamId: teamData.teamId }, teamData, {
+        upsert: true,
+      });
+    } catch (error) {
+      console.error(`Error fetching repository data for ${repoUrl}:`, error);
+    }
+  }
+};
+
+const fetchCodeFrequencyStats = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string
+) => {
+  let attempt = 0;
+  const maxAttempts = 10;
+  const delayBetweenAttempts = 2000;
+
+  while (attempt < maxAttempts) {
+    try {
+      const response = await octokit.rest.repos.getCodeFrequencyStats({
+        owner,
+        repo,
+      });
+
+      if (response.status === 200) {
+        return response.data;
+      } else if (response.status === 202) {
+        await new Promise(resolve => setTimeout(resolve, delayBetweenAttempts));
+        attempt++;
+      } else {
+        throw new Error('Failed to fetch code frequency stats');
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(
+          `Error fetching code frequency stats: ${error.message}`
+        );
+      }
+    }
+  }
+
+  throw new Error('Max attempts reached. Data may not be available yet.');
+};
+
+const fetchWithExponentialBackoff = async (
+  request: () => Promise<any>,
+  retries = 5,
+  delay = 1000
+): Promise<any> => {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await request();
+      return response;
+    } catch (err: any) {
+      if (
+        err.status === 403 &&
+        err.response?.headers['x-ratelimit-remaining'] === '0'
+      ) {
+        // Rate limit hit, perform backoff
+        const resetTime =
+          parseInt(err.response.headers['x-ratelimit-reset']) * 1000;
+        const waitTime = resetTime - Date.now();
+        console.warn(`Rate limit exceeded, waiting for ${waitTime} ms`);
+        await new Promise(resolve => setTimeout(resolve, waitTime));
+      } else if (
+        err.status === 403 &&
+        err.message.includes('SecondaryRateLimit')
+      ) {
+        // Handle secondary rate limit with exponential backoff
+        const backoffTime = delay * Math.pow(2, i); // Exponential backoff
+        console.warn(
+          `SecondaryRateLimit detected, retrying in ${backoffTime} ms...`
+        );
+        await new Promise(resolve => setTimeout(resolve, backoffTime));
+      } else {
+        throw err;
+      }
+    }
+  }
+  throw new Error('Max retries reached. Unable to complete the request.');
+};
+
+const fetchAllPagesWithBackoff = async (
+  request: (page: number) => Promise<any>,
+  retries = 5,
+  delay = 1000,
+  perPage = 100
+): Promise<any[]> => {
+  let page = 1;
+  let allData: any[] = [];
+  let hasMore = true;
+
+  while (hasMore) {
+    try {
+      const response = await fetchWithExponentialBackoff(
+        () => request(page),
+        retries,
+        delay
+      );
+      allData = allData.concat(response.data);
+
+      // Check if there are more pages
+      if (response.data.length < perPage) {
+        hasMore = false; // No more pages
+      } else {
+        page++;
+      }
+    } catch (error) {
+      console.error('Error fetching paginated data:', error);
+      throw error;
+    }
+  }
+
+  return allData;
+};
+
+const getFourMonthsAgo = (): string => {
+  const date = new Date();
+  date.setMonth(date.getMonth() - 4);
+  return date.toISOString(); // Format the date in ISO string (required by GitHub API)
+};
+
+export const setupPublicGitHubJob = () => {
+  // Schedule the job to run every day at 05:00
+  cron.schedule('0 5 * * *', async () => {
+    console.log('Running fetchPublicRepoData job:', new Date().toString());
+    try {
+      await fetchPublicRepoData();
+    } catch (err) {
+      console.error('Error in cron job fetchPublicRepoData:', err);
+    }
+  });
+
+  // To run the job immediately for testing
+  if (process.env.RUN_JOB_NOW === 'true') {
+    fetchPublicRepoData().catch(err => {
+      console.error('Error running job manually:', err);
+    });
+  }
+};
+
+export default setupPublicGitHubJob;

--- a/backend/jobs/publicGithubJob.ts
+++ b/backend/jobs/publicGithubJob.ts
@@ -30,22 +30,19 @@ const fetchPublicRepoData = async () => {
 const getPublicCourseData = async (course: any) => {
   if (!course.gitHubRepoLinks || course.gitHubRepoLinks.length === 0) return;
 
-  const app: App = getGitHubApp();
-  const genericOctokit = app.octokit; // Use a generic octokit instance
-
   for (const repoUrl of course.gitHubRepoLinks) {
     const urlParts = repoUrl.split('/');
     const owner = urlParts[3]; // Get the 'owner' part of the URL
     const repo = urlParts[4]; // Get the 'repo' part of the URL
 
     const installationId = await checkAppInstalled(owner);
+    const app: App = getGitHubApp();
 
     const octokit = installationId
       ? await app.getInstallationOctokit(installationId)
-      : genericOctokit;
+      : new Octokit();
 
     try {
-      // Fetch repository data using public Octokit instance
       const repoData = await octokit.rest.repos.get({
         owner,
         repo,

--- a/backend/jobs/publicGithubJob.ts
+++ b/backend/jobs/publicGithubJob.ts
@@ -257,31 +257,20 @@ const fetchCodeFrequencyStats = async (
   owner: string,
   repo: string
 ) => {
-  let attempt = 0;
-  const maxAttempts = 10;
-  const delayBetweenAttempts = 2000;
+  try {
+    const response = await octokit.rest.repos.getCodeFrequencyStats({
+      owner,
+      repo,
+    });
 
-  while (attempt < maxAttempts) {
-    try {
-      const response = await octokit.rest.repos.getCodeFrequencyStats({
-        owner,
-        repo,
-      });
-
-      if (response.status === 200) {
-        return response.data;
-      } else if (response.status === 202) {
-        await new Promise(resolve => setTimeout(resolve, delayBetweenAttempts));
-        attempt++;
-      } else {
-        throw new Error('Failed to fetch code frequency stats');
-      }
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        throw new Error(
-          `Error fetching code frequency stats: ${error.message}`
-        );
-      }
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      throw new Error('Failed to fetch code frequency stats');
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(`Error fetching code frequency stats: ${error.message}`);
     }
   }
 

--- a/backend/jobs/trofosJob.ts
+++ b/backend/jobs/trofosJob.ts
@@ -64,7 +64,7 @@ const fetchAndSaveTrofosData = async () => {
 
       for (const trofosProject of trofosProjectData) {
         const trofosProjectId = trofosProject.id;
-        if (trofosProject.course.id === courseId) {
+        if (trofosProject.course_id === courseId) {
           await fetchSingleTrofosProject(course, trofosProjectId, apiKey);
         }
       }

--- a/backend/models/Course.ts
+++ b/backend/models/Course.ts
@@ -45,15 +45,16 @@ export const courseSchema = new Schema<Course>({
     enum: ['GitHubOrg', 'Normal'],
     required: true,
   },
+  gitHubRepoLinks: [{ type: String }],
   gitHubOrgName: String,
+  repoNameFilter: String,
+  installationId: Number,
   jira: {
     isRegistered: { type: Boolean, required: true, default: false },
     cloudIds: [{ type: String }],
     accessToken: { type: String },
     refreshToken: { type: String },
   },
-  repoNameFilter: String,
-  installationId: Number,
 });
 
 const CourseModel = mongoose.model<Course>('Course', courseSchema);

--- a/backend/routes/courseRoutes.ts
+++ b/backend/routes/courseRoutes.ts
@@ -32,6 +32,7 @@ import {
   getRepositories,
   addRepositories,
   deleteRepository,
+  updateRepository,
 } from '../controllers/courseController';
 import { noCache } from '../middleware/noCache';
 
@@ -56,7 +57,7 @@ router.delete('/:id/tas/:userId', removeTAs);
 router.get('/:id/people', getPeople);
 router.get('/:id/repositories', getRepositories);
 router.post('/:id/repositories', addRepositories);
-// router.put('/:id/repositories/:repositoryIndex', updateRepository);
+router.patch('/:id/repositories/:repositoryIndex', updateRepository);
 router.delete('/:id/repositories/:repositoryIndex', deleteRepository);
 router.get('/:id/teamsets', getTeamSets);
 router.post('/:id/teamsets', addTeamSet);

--- a/backend/routes/courseRoutes.ts
+++ b/backend/routes/courseRoutes.ts
@@ -31,6 +31,7 @@ import {
   getCourseJiraRegistrationStatus,
   getRepositories,
   addRepositories,
+  deleteRepository,
 } from '../controllers/courseController';
 import { noCache } from '../middleware/noCache';
 
@@ -56,7 +57,7 @@ router.get('/:id/people', getPeople);
 router.get('/:id/repositories', getRepositories);
 router.post('/:id/repositories', addRepositories);
 // router.put('/:id/repositories/:repositoryIndex', updateRepository);
-// router.delete('/:id/repositories/:repositoryIndex', deleteRepository);
+router.delete('/:id/repositories/:repositoryIndex', deleteRepository);
 router.get('/:id/teamsets', getTeamSets);
 router.post('/:id/teamsets', addTeamSet);
 router.get('/:id/teamsets/names', getTeamSetsNames);

--- a/backend/routes/courseRoutes.ts
+++ b/backend/routes/courseRoutes.ts
@@ -30,6 +30,7 @@ import {
   getProjectManagementBoard,
   getCourseJiraRegistrationStatus,
   getRepositories,
+  addRepositories,
 } from '../controllers/courseController';
 import { noCache } from '../middleware/noCache';
 
@@ -53,6 +54,9 @@ router.patch('/:id/tas', updateTAs);
 router.delete('/:id/tas/:userId', removeTAs);
 router.get('/:id/people', getPeople);
 router.get('/:id/repositories', getRepositories);
+router.post('/:id/repositories', addRepositories);
+// router.put('/:id/repositories/:repositoryIndex', updateRepository);
+// router.delete('/:id/repositories/:repositoryIndex', deleteRepository);
 router.get('/:id/teamsets', getTeamSets);
 router.post('/:id/teamsets', addTeamSet);
 router.get('/:id/teamsets/names', getTeamSetsNames);

--- a/backend/routes/courseRoutes.ts
+++ b/backend/routes/courseRoutes.ts
@@ -29,6 +29,7 @@ import {
   updateTAs,
   getProjectManagementBoard,
   getCourseJiraRegistrationStatus,
+  getRepositories,
 } from '../controllers/courseController';
 import { noCache } from '../middleware/noCache';
 
@@ -51,6 +52,7 @@ router.post('/:id/tas', addTAs);
 router.patch('/:id/tas', updateTAs);
 router.delete('/:id/tas/:userId', removeTAs);
 router.get('/:id/people', getPeople);
+router.get('/:id/repositories', getRepositories);
 router.get('/:id/teamsets', getTeamSets);
 router.post('/:id/teamsets', addTeamSet);
 router.get('/:id/teamsets/names', getTeamSetsNames);

--- a/backend/routes/courseRoutes.ts
+++ b/backend/routes/courseRoutes.ts
@@ -31,7 +31,7 @@ import {
   getCourseJiraRegistrationStatus,
   getRepositories,
   addRepositories,
-  deleteRepository,
+  removeRepository,
   updateRepository,
 } from '../controllers/courseController';
 import { noCache } from '../middleware/noCache';
@@ -58,7 +58,7 @@ router.get('/:id/people', getPeople);
 router.get('/:id/repositories', getRepositories);
 router.post('/:id/repositories', addRepositories);
 router.patch('/:id/repositories/:repositoryIndex', updateRepository);
-router.delete('/:id/repositories/:repositoryIndex', deleteRepository);
+router.delete('/:id/repositories/:repositoryIndex', removeRepository);
 router.get('/:id/teamsets', getTeamSets);
 router.post('/:id/teamsets', addTeamSet);
 router.get('/:id/teamsets/names', getTeamSetsNames);

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -439,7 +439,7 @@ export const getPeopleFromCourse = async (courseId: string) => {
   };
 };
 
-/*----------------------------------------People----------------------------------------*/
+/*-------------------------------------Repositories-------------------------------------*/
 export const getRepositoriesFromCourse = async (courseId: string) => {
   const course = await CourseModel.findById(courseId);
 

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -439,6 +439,19 @@ export const getPeopleFromCourse = async (courseId: string) => {
   };
 };
 
+/*----------------------------------------People----------------------------------------*/
+export const getRepositoriesFromCourse = async (courseId: string) => {
+  const course = await CourseModel.findById(courseId);
+
+  if (!course) {
+    throw new NotFoundError('Course not found');
+  }
+
+  return {
+    repositories: course.gitHubRepoLinks,
+  };
+};
+
 /*----------------------------------------TeamSet----------------------------------------*/
 export const getTeamSetsFromCourse = async (
   accountId: string,

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -469,6 +469,32 @@ export const addRepositoriesToCourse = async (
   await course.save();
 };
 
+export const editRepository = async (
+  courseId: string,
+  repositoryIndex: number,
+  updateData: Record<string, unknown>
+) => {
+  const course = await CourseModel.findById(courseId);
+  if (!course) {
+    throw new NotFoundError('Course not found');
+  }
+
+  // Check if the repositoryIndex is valid
+  if (repositoryIndex < 0 || repositoryIndex >= course.gitHubRepoLinks.length) {
+    throw new NotFoundError('Repository not found');
+  }
+
+  // Make sure you're only updating the repoLink (a string) instead of an object
+  if (typeof updateData.repoLink === 'string') {
+    course.gitHubRepoLinks[repositoryIndex] = updateData.repoLink; // Directly set the new repo link
+  } else {
+    throw new Error('Invalid repository link format');
+  }
+
+  // Save the updated course
+  await course.save();
+};
+
 export const removeRepositoryFromCourse = async (
   courseId: string,
   repositoryIndex: number

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -452,6 +452,23 @@ export const getRepositoriesFromCourse = async (courseId: string) => {
   };
 };
 
+export const addRepositoriesToCourse = async (
+  courseId: string,
+  repositories: { gitHubRepoLink: string }[]
+) => {
+  const course = await CourseModel.findById(courseId);
+
+  if (!course) {
+    throw new NotFoundError('Course not found');
+  }
+
+  for (const repository of repositories) {
+    course.gitHubRepoLinks.push(repository.gitHubRepoLink);
+  }
+
+  await course.save();
+};
+
 /*----------------------------------------TeamSet----------------------------------------*/
 export const getTeamSetsFromCourse = async (
   accountId: string,

--- a/backend/services/courseService.ts
+++ b/backend/services/courseService.ts
@@ -469,6 +469,27 @@ export const addRepositoriesToCourse = async (
   await course.save();
 };
 
+export const removeRepositoryFromCourse = async (
+  courseId: string,
+  repositoryIndex: number
+) => {
+  const course = await CourseModel.findById(courseId);
+  if (!course) {
+    throw new NotFoundError('Course not found');
+  }
+
+  // Check if the repositoryIndex is valid
+  if (repositoryIndex < 0 || repositoryIndex >= course.gitHubRepoLinks.length) {
+    throw new NotFoundError('Repository not found');
+  }
+
+  // Remove the repository from the array
+  course.gitHubRepoLinks.splice(repositoryIndex, 1);
+
+  // Save the updated course
+  await course.save();
+};
+
 /*----------------------------------------TeamSet----------------------------------------*/
 export const getTeamSetsFromCourse = async (
   accountId: string,

--- a/backend/test/controllers/courseController.test.ts
+++ b/backend/test/controllers/courseController.test.ts
@@ -20,6 +20,7 @@ import {
   getCourses,
   getPeople,
   getProjectManagementBoard,
+  getRepositories,
   getTeachingTeam,
   getTeamSets,
   getTeamSetsNames,
@@ -1005,6 +1006,55 @@ describe('courseController', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({
         error: 'Failed to retrieve people',
+      });
+    });
+  });
+
+  describe('getRepositories', () => {
+    it('should get repositories in a course', async () => {
+      const req = mockRequest({}, { id: 'courseId' });
+      const res = mockResponse();
+      const mockRepositories = {
+        repositories: ['repo1', 'repo2'],
+      };
+
+      jest
+        .spyOn(courseService, 'getRepositoriesFromCourse')
+        .mockResolvedValue(mockRepositories as any);
+
+      await getRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockRepositories);
+    });
+
+    it('should handle NotFoundError and send a 404 status', async () => {
+      const req = mockRequest({}, { id: 'courseId' });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'getRepositoriesFromCourse')
+        .mockRejectedValue(new NotFoundError('Course not found'));
+
+      await getRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Course not found' });
+    });
+
+    it('should handle errors when getting repositories', async () => {
+      const req = mockRequest({}, { id: 'courseId' });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'getRepositoriesFromCourse')
+        .mockRejectedValue(new Error('Failed to retrieve repositories'));
+
+      await getRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Failed to retrieve repositories',
       });
     });
   });

--- a/backend/test/controllers/courseController.test.ts
+++ b/backend/test/controllers/courseController.test.ts
@@ -1064,10 +1064,15 @@ describe('courseController', () => {
 
   describe('addRepositories', () => {
     it('should add repositories to a course', async () => {
-      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const req = mockRequest(
+        { gitHubRepoLink: ['repo1', 'repo2'] },
+        { id: 'courseId' }
+      );
       const res = mockResponse();
 
-      jest.spyOn(courseService, 'addRepositoriesToCourse').mockResolvedValue(undefined);
+      jest
+        .spyOn(courseService, 'addRepositoriesToCourse')
+        .mockResolvedValue(undefined);
 
       await addRepositories(req, res);
 
@@ -1078,7 +1083,10 @@ describe('courseController', () => {
     });
 
     it('should handle NotFoundError and send a 404 status', async () => {
-      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const req = mockRequest(
+        { gitHubRepoLink: ['repo1', 'repo2'] },
+        { id: 'courseId' }
+      );
       const res = mockResponse();
 
       jest
@@ -1092,7 +1100,10 @@ describe('courseController', () => {
     });
 
     it('should handle errors when adding repositories', async () => {
-      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const req = mockRequest(
+        { gitHubRepoLink: ['repo1', 'repo2'] },
+        { id: 'courseId' }
+      );
       const res = mockResponse();
 
       jest
@@ -1110,12 +1121,13 @@ describe('courseController', () => {
 
   describe('updateRepository', () => {
     it('should update repository in a course', async () => {
-      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const req = mockRequest(
+        { repoLink: 'repo3' },
+        { id: 'courseId', repositoryIndex: 1 }
+      );
       const res = mockResponse();
 
-      jest
-        .spyOn(courseService, 'editRepository')
-        .mockResolvedValue(undefined);
+      jest.spyOn(courseService, 'editRepository').mockResolvedValue(undefined);
 
       await updateRepository(req, res);
 
@@ -1126,7 +1138,10 @@ describe('courseController', () => {
     });
 
     it('should handle NotFoundError and send a 404 status', async () => {
-      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const req = mockRequest(
+        { repoLink: 'repo3' },
+        { id: 'courseId', repositoryIndex: 1 }
+      );
       const res = mockResponse();
 
       jest
@@ -1140,7 +1155,10 @@ describe('courseController', () => {
     });
 
     it('should handle errors when updating repository', async () => {
-      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const req = mockRequest(
+        { repoLink: 'repo3' },
+        { id: 'courseId', repositoryIndex: 1 }
+      );
       const res = mockResponse();
 
       jest

--- a/backend/test/controllers/courseController.test.ts
+++ b/backend/test/controllers/courseController.test.ts
@@ -5,6 +5,7 @@ import {
   addAssessments,
   addFaculty,
   addMilestone,
+  addRepositories,
   addSprint,
   addStudents,
   addStudentsToTeams,
@@ -26,10 +27,12 @@ import {
   getTeamSetsNames,
   getTimeline,
   removeFaculty,
+  removeRepository,
   removeStudents,
   removeTAs,
   updateCourse,
   updateFaculty,
+  updateRepository,
   updateStudents,
   updateTAs,
 } from '../../controllers/courseController';
@@ -1055,6 +1058,148 @@ describe('courseController', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({
         error: 'Failed to retrieve repositories',
+      });
+    });
+  });
+
+  describe('addRepositories', () => {
+    it('should add repositories to a course', async () => {
+      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const res = mockResponse();
+
+      jest.spyOn(courseService, 'addRepositoriesToCourse').mockResolvedValue(undefined);
+
+      await addRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Repositories added to the course successfully',
+      });
+    });
+
+    it('should handle NotFoundError and send a 404 status', async () => {
+      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'addRepositoriesToCourse')
+        .mockRejectedValue(new NotFoundError('Course not found'));
+
+      await addRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Course not found' });
+    });
+
+    it('should handle errors when adding repositories', async () => {
+      const req = mockRequest({ gitHubRepoLink: ['repo1', 'repo2'] }, { id: 'courseId' });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'addRepositoriesToCourse')
+        .mockRejectedValue(new Error('Error adding repositories'));
+
+      await addRepositories(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Failed to add repositories',
+      });
+    });
+  });
+
+  describe('updateRepository', () => {
+    it('should update repository in a course', async () => {
+      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'editRepository')
+        .mockResolvedValue(undefined);
+
+      await updateRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Repository updated successfully',
+      });
+    });
+
+    it('should handle NotFoundError and send a 404 status', async () => {
+      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'editRepository')
+        .mockRejectedValue(new NotFoundError('Course not found'));
+
+      await updateRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Course not found' });
+    });
+
+    it('should handle errors when updating repository', async () => {
+      const req = mockRequest({ repoLink: 'repo3' }, { id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'editRepository')
+        .mockRejectedValue(new Error('Error updating repository'));
+
+      await updateRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Failed to update repository',
+      });
+    });
+  });
+
+  describe('removeRepository', () => {
+    it('should remove repository from a course', async () => {
+      const req = mockRequest({ id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'removeRepositoryFromCourse')
+        .mockResolvedValue(undefined);
+
+      await removeRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Repository removed from the course successfully',
+      });
+    });
+
+    it('should handle NotFoundError and send a 404 status', async () => {
+      const req = mockRequest({ id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'removeRepositoryFromCourse')
+        .mockRejectedValue(new NotFoundError('Course not found'));
+
+      await removeRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Course not found' });
+    });
+
+    it('should handle errors when removing repository', async () => {
+      const req = mockRequest({ id: 'courseId', repositoryIndex: 1 });
+      const res = mockResponse();
+
+      jest
+        .spyOn(courseService, 'removeRepositoryFromCourse')
+        .mockRejectedValue(new Error('Failed to remove repository'));
+
+      await removeRepository(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Failed to remove repository',
       });
     });
   });

--- a/backend/test/services/courseService.test.ts
+++ b/backend/test/services/courseService.test.ts
@@ -928,15 +928,17 @@ describe('courseService', () => {
 
   describe('getRepositoriesFromCourse', () => {
     it('should get repositories from a course', async () => {
-      // Mock course data
       const course = await CourseModel.findOne({ _id: courseId });
       if (!course) {
         throw new Error('Course not found');
       }
 
+      const repo1 = 'https://github.com/org/repo1';
+      const repo2 = 'https://github.com/org/repo2';
+
       // Add repository links to the course
-      course.gitHubRepoLinks.push('https://github.com/org/repo1');
-      course.gitHubRepoLinks.push('https://github.com/org/repo2');
+      course.gitHubRepoLinks.push(repo1);
+      course.gitHubRepoLinks.push(repo2);
       await course.save();
 
       const repositories = await getRepositoriesFromCourse(courseId);
@@ -944,8 +946,8 @@ describe('courseService', () => {
       // Ensure repositories are returned correctly
       expect(repositories).toBeDefined();
       expect(repositories.repositories.length).toBe(2);
-      expect(repositories.repositories).toContain('https://github.com/org/repo1');
-      expect(repositories.repositories).toContain('https://github.com/org/repo2');
+      expect(repositories.repositories).toContain(repo1);
+      expect(repositories.repositories).toContain(repo2);
     });
 
     it('should throw NotFoundError for invalid courseId', async () => {
@@ -1012,7 +1014,9 @@ describe('courseService', () => {
       await editRepository(courseId, repositoryIndex, updateData);
 
       const updatedCourse = await CourseModel.findById(courseId);
-      expect(updatedCourse?.gitHubRepoLinks[repositoryIndex]).toBe(updatedRepoLink);
+      expect(updatedCourse?.gitHubRepoLinks[repositoryIndex]).toBe(
+        updatedRepoLink
+      );
     });
 
     it('should throw NotFoundError for invalid courseId', async () => {

--- a/backend/test/services/courseService.test.ts
+++ b/backend/test/services/courseService.test.ts
@@ -15,11 +15,13 @@ import UserModel from '../../models/User';
 import {
   addFacultyToCourse,
   addMilestoneToCourse,
+  addRepositoriesToCourse,
   addSprintToCourse,
   addStudentsToCourse,
   addTAsToCourse,
   createNewCourse,
   deleteCourseById,
+  editRepository,
   getAssessmentsFromCourse,
   getCourseById,
   getCourseCodeById,
@@ -29,9 +31,11 @@ import {
   getCoursesForUser,
   getPeopleFromCourse,
   getProjectManagementBoardFromCourse,
+  getRepositoriesFromCourse,
   getTeamSetNamesFromCourse,
   getTeamSetsFromCourse,
   removeFacultyFromCourse,
+  removeRepositoryFromCourse,
   removeStudentsFromCourse,
   removeTAsFromCourse,
   updateCourseById,
@@ -919,6 +923,173 @@ describe('courseService', () => {
       await expect(getPeopleFromCourse(invalidCourseId)).rejects.toThrow(
         NotFoundError
       );
+    });
+  });
+
+  describe('getRepositoriesFromCourse', () => {
+    it('should get repositories from a course', async () => {
+      // Mock course data
+      const course = await CourseModel.findOne({ _id: courseId });
+      if (!course) {
+        throw new Error('Course not found');
+      }
+
+      // Add repository links to the course
+      course.gitHubRepoLinks.push('https://github.com/org/repo1');
+      course.gitHubRepoLinks.push('https://github.com/org/repo2');
+      await course.save();
+
+      const repositories = await getRepositoriesFromCourse(courseId);
+
+      // Ensure repositories are returned correctly
+      expect(repositories).toBeDefined();
+      expect(repositories.repositories.length).toBe(2);
+      expect(repositories.repositories).toContain('https://github.com/org/repo1');
+      expect(repositories.repositories).toContain('https://github.com/org/repo2');
+    });
+
+    it('should throw NotFoundError for invalid courseId', async () => {
+      const invalidCourseId = new mongoose.Types.ObjectId().toString();
+
+      // Ensure the function throws NotFoundError if course is not found
+      await expect(getRepositoriesFromCourse(invalidCourseId)).rejects.toThrow(
+        NotFoundError
+      );
+    });
+  });
+
+  describe('addRepositoriesToCourse', () => {
+    const repo1 = 'https://github.com/org/repo1';
+    const repo2 = 'https://github.com/org/repo2';
+
+    it('should add repositories to a course', async () => {
+      const repositories = [
+        { gitHubRepoLink: repo1 },
+        { gitHubRepoLink: repo2 },
+      ];
+
+      await addRepositoriesToCourse(courseId, repositories);
+
+      const updatedCourse = await CourseModel.findById(courseId);
+      expect(updatedCourse?.gitHubRepoLinks).toContain(repo1);
+      expect(updatedCourse?.gitHubRepoLinks).toContain(repo2);
+    });
+
+    it('should throw NotFoundError for invalid courseId', async () => {
+      const invalidCourseId = new mongoose.Types.ObjectId().toString();
+      const repositories = [{ gitHubRepoLink: repo1 }];
+
+      await expect(
+        addRepositoriesToCourse(invalidCourseId, repositories)
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('editRepository', () => {
+    const initialRepoLink = 'https://github.com/org/repo1';
+    const updatedRepoLink = 'https://github.com/org/repo1-updated';
+    const invalidRepoLink = 123; // To test invalid repo format
+
+    beforeEach(async () => {
+      // Find the course by ID
+      const course = await CourseModel.findById(courseId);
+
+      if (!course) {
+        throw new NotFoundError('Course not found');
+      }
+
+      // Add a repository directly to the course
+      course.gitHubRepoLinks.push(initialRepoLink);
+
+      // Save the updated course
+      await course.save();
+    });
+
+    it('should update a repository in a course', async () => {
+      const repositoryIndex = 0; // Assuming the repo added above is at index 0
+      const updateData = { repoLink: updatedRepoLink };
+
+      await editRepository(courseId, repositoryIndex, updateData);
+
+      const updatedCourse = await CourseModel.findById(courseId);
+      expect(updatedCourse?.gitHubRepoLinks[repositoryIndex]).toBe(updatedRepoLink);
+    });
+
+    it('should throw NotFoundError for invalid courseId', async () => {
+      const invalidCourseId = new mongoose.Types.ObjectId().toString();
+      const repositoryIndex = 0;
+      const updateData = { repoLink: updatedRepoLink };
+
+      await expect(
+        editRepository(invalidCourseId, repositoryIndex, updateData)
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw NotFoundError for invalid repositoryIndex', async () => {
+      const invalidRepositoryIndex = 999; // Out of bounds
+      const updateData = { repoLink: updatedRepoLink };
+
+      await expect(
+        editRepository(courseId, invalidRepositoryIndex, updateData)
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw an error for invalid repository link format', async () => {
+      const repositoryIndex = 0; // Valid repository index
+      const updateData = { repoLink: invalidRepoLink }; // Invalid repoLink format
+
+      await expect(
+        editRepository(courseId, repositoryIndex, updateData)
+      ).rejects.toThrow('Invalid repository link format');
+
+      // Ensure the repository was not updated
+      const course = await CourseModel.findById(courseId);
+      expect(course?.gitHubRepoLinks[repositoryIndex]).toBe(initialRepoLink);
+    });
+  });
+
+  describe('removeRepositoryFromCourse', () => {
+    const initialRepoLink = 'https://github.com/org/repo1';
+
+    beforeEach(async () => {
+      // Find the course by ID
+      const course = await CourseModel.findById(courseId);
+
+      if (!course) {
+        throw new NotFoundError('Course not found');
+      }
+
+      // Add a repository directly to the course
+      course.gitHubRepoLinks.push(initialRepoLink);
+
+      // Save the updated course
+      await course.save();
+    });
+
+    it('should remove a repository from a course', async () => {
+      const repositoryIndex = 0; // Assuming the repo added above is at index 0
+
+      await removeRepositoryFromCourse(courseId, repositoryIndex);
+
+      const updatedCourse = await CourseModel.findById(courseId);
+      expect(updatedCourse?.gitHubRepoLinks.length).toBe(0);
+    });
+
+    it('should throw NotFoundError for invalid courseId', async () => {
+      const invalidCourseId = new mongoose.Types.ObjectId().toString();
+      const repositoryIndex = 0; // Valid index
+
+      await expect(
+        removeRepositoryFromCourse(invalidCourseId, repositoryIndex)
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw NotFoundError for invalid repositoryIndex', async () => {
+      const invalidRepositoryIndex = 999; // Out of bounds
+
+      await expect(
+        removeRepositoryFromCourse(courseId, invalidRepositoryIndex)
+      ).rejects.toThrow(NotFoundError);
     });
   });
 

--- a/multi-git-dashboard/src/components/Navbar.tsx
+++ b/multi-git-dashboard/src/components/Navbar.tsx
@@ -90,6 +90,8 @@ const Navbar: React.FC = () => {
   const determineActiveTab = (path: string) => {
     if (path.startsWith('/courses/[id]/people')) {
       return 'People';
+    } else if (path.startsWith('/courses/[id]/repositories')) {
+      return 'Repositories';
     } else if (path.startsWith('/courses/[id]/teams')) {
       return 'Teams';
     } else if (path.startsWith('/courses/[id]/timeline')) {
@@ -144,6 +146,10 @@ const Navbar: React.FC = () => {
     {
       link: `/courses/${courseId}/people`,
       label: 'People',
+    },
+    {
+      link: `/courses/${courseId}/repositories`,
+      label: 'Repositories',
     },
     {
       link: `/courses/${courseId}/teams`,

--- a/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
+++ b/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
@@ -15,11 +15,11 @@ const RepositoryForm: React.FC<RepositoryFormProps> = ({
   const apiRoute = `/api/courses/${courseId}/repositories`;
 
   // CSV template with a single column for GitHub repo links
-  const csvTemplateHeaders = ['repoLink'];
+  const csvTemplateHeaders = ['gitHubRepoLink'];
 
   const form = useForm({
     initialValues: {
-      repoLink: '',
+      gitHubRepoLink: '',
     },
   });
   const [error, setError] = useState<string | null>(null);
@@ -31,7 +31,7 @@ const RepositoryForm: React.FC<RepositoryFormProps> = ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        repository: form.values.repoLink,
+        items: [{ gitHubRepoLink: form.values.gitHubRepoLink }],
       }),
     });
 
@@ -60,10 +60,10 @@ const RepositoryForm: React.FC<RepositoryFormProps> = ({
         <TextInput
           withAsterisk
           label="GitHub Repository Link"
-          {...form.getInputProps('repoLink')}
-          value={form.values.repoLink}
+          {...form.getInputProps('gitHubRepoLink')}
+          value={form.values.gitHubRepoLink}
           onChange={event =>
-            form.setFieldValue('repoLink', event.currentTarget.value)
+            form.setFieldValue('gitHubRepoLink', event.currentTarget.value)
           }
         />
         <Button type="submit" style={{ marginTop: '16px' }}>

--- a/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
+++ b/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
@@ -67,7 +67,7 @@ const RepositoryForm: React.FC<RepositoryFormProps> = ({
           }
         />
         <Button type="submit" style={{ marginTop: '16px' }}>
-          Create Repository
+          Add Repository
         </Button>
       </form>
       <Divider label="or Upload CSV" size="lg" />

--- a/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
+++ b/multi-git-dashboard/src/components/forms/RepositoryForm.tsx
@@ -1,0 +1,86 @@
+import { Box, Button, Divider, Notification, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useState } from 'react';
+import CSVUpload from '../csv/CSVUpload';
+
+interface RepositoryFormProps {
+  courseId: string | string[] | undefined;
+  onRepositoryCreated: () => void;
+}
+
+const RepositoryForm: React.FC<RepositoryFormProps> = ({
+  courseId,
+  onRepositoryCreated,
+}) => {
+  const apiRoute = `/api/courses/${courseId}/repositories`;
+
+  // CSV template with a single column for GitHub repo links
+  const csvTemplateHeaders = ['repoLink'];
+
+  const form = useForm({
+    initialValues: {
+      repoLink: '',
+    },
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmitForm = async () => {
+    const response = await fetch(apiRoute, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        repository: form.values.repoLink,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      setError(
+        errorData.message ||
+          'An error occurred while submitting the repository link.'
+      );
+      return;
+    }
+
+    await response.json();
+    onRepositoryCreated();
+  };
+
+  return (
+    <Box maw={300} mx="auto">
+      {error && (
+        <Notification title="Error" color="red" onClose={() => setError(null)}>
+          {error}
+        </Notification>
+      )}
+      <Divider label="Enter GitHub Repository Link" size="lg" />
+      <form onSubmit={form.onSubmit(handleSubmitForm)}>
+        <TextInput
+          withAsterisk
+          label="GitHub Repository Link"
+          {...form.getInputProps('repoLink')}
+          value={form.values.repoLink}
+          onChange={event =>
+            form.setFieldValue('repoLink', event.currentTarget.value)
+          }
+        />
+        <Button type="submit" style={{ marginTop: '16px' }}>
+          Create Repository
+        </Button>
+      </form>
+      <Divider label="or Upload CSV" size="lg" />
+      <CSVUpload
+        headers={csvTemplateHeaders}
+        onProcessComplete={onRepositoryCreated}
+        onError={setError}
+        filename="repository_links_template.csv"
+        uploadButtonString="Upload Repository Links"
+        urlString={apiRoute}
+      />
+    </Box>
+  );
+};
+
+export default RepositoryForm;

--- a/multi-git-dashboard/src/components/forms/UpdateRepositoryForm.tsx
+++ b/multi-git-dashboard/src/components/forms/UpdateRepositoryForm.tsx
@@ -1,0 +1,80 @@
+import { Box, Button, Group, Notification, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useState } from 'react';
+
+interface UpdateRepositoryFormProps {
+  courseId: string;
+  repository: string | null; // Updated type to reflect repository structure
+  repositoryIndex: number | null;
+  onRepositoryUpdated: () => void; // Updated callback name
+}
+
+const UpdateRepositoryForm: React.FC<UpdateRepositoryFormProps> = ({
+  courseId,
+  repository,
+  repositoryIndex,
+  onRepositoryUpdated,
+}) => {
+  // Assuming that repository has a unique identifier such as _id
+  const apiRoute = `/api/courses/${courseId}/repositories/${repositoryIndex}`;
+
+  const form = useForm({
+    initialValues: {
+      repoLink: repository || '', // Update form fields to match repository fields
+    },
+  });
+
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmitForm = async () => {
+    const requestBody: Record<string, string> = {
+      repoLink: form.values.repoLink,
+    };
+
+    try {
+      const response = await fetch(apiRoute, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update repository');
+      }
+
+      await response.json();
+      onRepositoryUpdated(); // Trigger update after successful submission
+    } catch (error) {
+      setError('Error updating repository. Please try again.');
+    }
+  };
+
+  return (
+    <Box maw={300} mx="auto">
+      {error && (
+        <Notification title="Error" color="red" onClose={() => setError(null)}>
+          {error}
+        </Notification>
+      )}
+      <form onSubmit={form.onSubmit(handleSubmitForm)}>
+        <TextInput
+          label="Repository Link"
+          {...form.getInputProps('repoLink')}
+          value={form.values.repoLink}
+          onChange={event =>
+            form.setFieldValue('repoLink', event.currentTarget.value)
+          }
+        />
+        <Group my={16}>
+          <Button type="submit" style={{ marginTop: '16px' }}>
+            Update Repository
+          </Button>
+        </Group>
+      </form>
+    </Box>
+  );
+};
+
+export default UpdateRepositoryForm;

--- a/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
+++ b/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import {
+  Button,
+  Container,
+  Divider,
+  Group,
+  Modal,
+  Space,
+  Table,
+} from '@mantine/core';
+import Role from '@shared/types/auth/Role';
+import { User } from '@shared/types/User';
+import RepositoryForm from '../forms/RepositoryForm';
+
+interface RepositoryInfoProps {
+  courseId: string;
+  repositories: string[];
+  hasFacultyPermission: boolean;
+  onUpdate: () => void;
+}
+
+const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
+  courseId,
+  repositories,
+  hasFacultyPermission,
+  onUpdate,
+}) => {
+  const [isAddingRepository, setIsAddingRepository] = useState(false);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [isEditingRepository, setIsEditingRepository] = useState(false);
+  const [selectedRepository, setSelectedRepository] = useState<string | null>(
+    null
+  );
+
+  const [isUpdatingRepository, setIsUpdatingRepository] = useState(false);
+
+  const apiRouteRepository = `/api/courses/${courseId}/repository/`;
+
+  const toggleAddRepository = () => setIsAddingRepository(!isAddingRepository);
+
+  const toggleIsEditing = () => setIsEditing(!isEditing);
+
+  const toggleUpdateRepository = () =>
+    setIsUpdatingRepository(!isUpdatingRepository);
+
+  const handleDeleteRepository = async (repository: string) => {
+    try {
+      const apiRoute = apiRouteRepository;
+
+      const response = await fetch(apiRoute, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      await response.json();
+      onUpdate();
+    } catch (error) {
+      console.error('Error deleting repository:', error);
+    }
+  };
+
+  const openEditModal = (repository: string) => {
+    setSelectedRepository(repository);
+    setIsEditingRepository(true);
+  };
+
+  const handleUpdate = () => {
+    onUpdate();
+  };
+
+  const csvHeaders = ['identifier', 'name', 'gitHandle'];
+
+  return (
+    <Container>
+      {hasFacultyPermission && (
+        <Group my={16}>
+          {isEditing ? (
+            <>
+              <Button onClick={toggleUpdateRepository}>
+                Update Repository
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button onClick={toggleAddRepository}>Add Repository</Button>
+            </>
+          )}
+          <Button onClick={toggleIsEditing}>
+            {isEditing ? 'Finish Edit' : 'Edit Details'}
+          </Button>
+        </Group>
+      )}
+      <Modal
+        opened={isAddingRepository}
+        onClose={toggleAddRepository}
+        title="Add Repository"
+      >
+        <RepositoryForm
+          courseId={courseId}
+          onRepositoryCreated={handleUpdate}
+        />
+      </Modal>
+      <Divider label="Public GitHub Repositories" size="lg" />
+      {
+        <Table>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th style={{ textAlign: 'left', width: '83%' }}>
+                Repository
+              </Table.Th>
+              <Table.Th style={{ textAlign: 'left', width: '7%' }} />
+              <Table.Th style={{ textAlign: 'left', width: '10%' }} />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {repositories &&
+              repositories.length > 0 &&
+              repositories.map(repository => (
+                <Table.Tr key={repository}>
+                  <Table.Td style={{ textAlign: 'left' }}>
+                    {repository}
+                  </Table.Td>
+                  {isEditing && (
+                    <Table.Td>
+                      <Button
+                        size="compact-xs"
+                        variant="light"
+                        onClick={() => openEditModal(repository)}
+                      >
+                        Edit
+                      </Button>
+                    </Table.Td>
+                  )}
+                  {isEditing && (
+                    <Table.Td>
+                      <Button
+                        size="compact-xs"
+                        variant="light"
+                        color="red"
+                        onClick={() => handleDeleteRepository(repository)}
+                      >
+                        Remove
+                      </Button>
+                    </Table.Td>
+                  )}
+                </Table.Tr>
+              ))}
+          </Table.Tbody>
+        </Table>
+      }
+      <Space h="md" />
+    </Container>
+  );
+};
+
+export default RepositoryInfo;

--- a/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
+++ b/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
@@ -35,9 +35,9 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
   const toggleAddRepository = () => setIsAddingRepository(!isAddingRepository);
   const toggleIsEditing = () => setIsEditing(!isEditing);
 
-  const handleDeleteRepository = async (repository: string) => {
+  const handleDeleteRepository = async (repositoryIndex: number) => {
     try {
-      const response = await fetch(`${apiRouteRepository}${repository}`, {
+      const response = await fetch(`${apiRouteRepository}/${repositoryIndex}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
@@ -49,7 +49,7 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
       }
 
       await response.json();
-      onUpdate();
+      onUpdate(); // Trigger an update after deletion
     } catch (error) {
       console.error('Error deleting repository:', error);
     }
@@ -106,8 +106,8 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
-            {repositories.map(repository => (
-              <Table.Tr key={repository}>
+            {repositories.map((repository, index) => (
+              <Table.Tr key={index}>
                 <Table.Td>{repository}</Table.Td>
                 {isEditing && (
                   <>
@@ -125,7 +125,7 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
                         size="xs"
                         variant="light"
                         color="red"
-                        onClick={() => handleDeleteRepository(repository)}
+                        onClick={() => handleDeleteRepository(index)}
                       >
                         Remove
                       </Button>

--- a/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
+++ b/multi-git-dashboard/src/components/views/RepositoryInfo.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from '@mantine/core';
 import RepositoryForm from '../forms/RepositoryForm';
+import UpdateRepositoryForm from '../forms/UpdateRepositoryForm';
 
 interface RepositoryInfoProps {
   courseId: string;
@@ -25,14 +26,20 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
   onUpdate,
 }) => {
   const [isAddingRepository, setIsAddingRepository] = useState(false);
+  const [isEditingRepository, setIsEditingRepository] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [selectedRepository, setSelectedRepository] = useState<string | null>(
     null
   );
+  const [selectedRepositoryIndex, setSelectedRepositoryIndex] = useState<
+    number | null
+  >(null);
 
   const apiRouteRepository = `/api/courses/${courseId}/repositories/`;
 
   const toggleAddRepository = () => setIsAddingRepository(!isAddingRepository);
+  const toggleEditRepository = () =>
+    setIsEditingRepository(!isEditingRepository);
   const toggleIsEditing = () => setIsEditing(!isEditing);
 
   const handleDeleteRepository = async (repositoryIndex: number) => {
@@ -55,14 +62,17 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
     }
   };
 
-  const openEditModal = (repository: string) => {
+  const openEditModal = (repository: string, repositoryIndex: number) => {
     setSelectedRepository(repository);
-    setIsAddingRepository(true); // Reuse the same modal for adding and editing
+    setSelectedRepositoryIndex(repositoryIndex);
+    setIsEditingRepository(true); // Reuse the same modal for adding and editing
   };
 
   const handleUpdate = () => {
     setIsAddingRepository(false);
+    setIsEditingRepository(false);
     setSelectedRepository(null);
+    setSelectedRepositoryIndex(null);
     onUpdate();
   };
 
@@ -85,6 +95,19 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
         <RepositoryForm
           courseId={courseId}
           onRepositoryCreated={handleUpdate}
+        />
+      </Modal>
+
+      <Modal
+        opened={isEditingRepository}
+        onClose={toggleEditRepository}
+        title="Edit Repository" // Update title
+      >
+        <UpdateRepositoryForm
+          courseId={courseId}
+          repository={selectedRepository}
+          repositoryIndex={selectedRepositoryIndex} // Pass the index as a prop
+          onRepositoryUpdated={handleUpdate}
         />
       </Modal>
 
@@ -115,7 +138,7 @@ const RepositoryInfo: React.FC<RepositoryInfoProps> = ({
                       <Button
                         size="xs"
                         variant="light"
-                        onClick={() => openEditModal(repository)}
+                        onClick={() => openEditModal(repository, index)}
                       >
                         Edit
                       </Button>

--- a/multi-git-dashboard/src/pages/courses/[id]/repositories/index.tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/repositories/index.tsx
@@ -1,0 +1,65 @@
+import RepositoryInfo from '@/components/views/RepositoryInfo';
+import { hasFacultyPermission } from '@/lib/auth/utils';
+import { Container } from '@mantine/core';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const RepositoryListPage: React.FC = () => {
+  const router = useRouter();
+  const { id } = router.query as {
+    id: string;
+  };
+
+  const apiRoute = `/api/courses/${id}/repositories`;
+  // const apiRouteAccountStatus = '/api/accounts/status';
+
+  const [repositories, setRepositories] = useState<string[]>([]);
+
+  const permission = hasFacultyPermission();
+
+  const onUpdate = () => {
+    fetchRepositories();
+  };
+
+  useEffect(() => {
+    if (router.isReady) {
+      fetchRepositories();
+    }
+  }, [router.isReady]);
+
+  const fetchRepositories = async () => {
+    try {
+      const response = await fetch(apiRoute, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        console.error('Error fetching repositories:', response.statusText);
+      } else {
+        const data = await response.json();
+        const { repositories } = data;
+        setRepositories(repositories);
+      }
+    } catch (error) {
+      console.error('Error fetching repositories:', error);
+    }
+  };
+
+  return (
+    <Container>
+      {id && (
+        <RepositoryInfo
+          courseId={id}
+          repositories={repositories}
+          hasFacultyPermission={permission}
+          onUpdate={onUpdate}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default RepositoryListPage;

--- a/shared/types/Course.ts
+++ b/shared/types/Course.ts
@@ -37,6 +37,8 @@ export interface Course {
   sprints: Sprint[];
   milestones: Milestone[];
   courseType: CourseType;
+  // GitHub Repo for non GitHub Org
+  gitHubRepoLinks: String[]
   // start 'GitHubOrg' fields
   gitHubOrgName?: string;
   repoNameFilter?: string;


### PR DESCRIPTION
## Description

Extend CRISP course features for public GitHub repositories.

## Changes

- Create Repository tab.
- Add list of public GitHub repositories with CSV upload functionality
- Edit team can allow public GitHub repositories

## Screenshots (if applicable)

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/4e2fad69-0587-4b99-90b4-dc35bde44f0b">

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/6e8b05f3-4e43-4930-b350-2bb2a9b2e8f1">

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/5a010f56-cc60-4430-9a5f-c4a11f655a10">

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/4622a8db-247e-4ce3-b476-7cb2bf5fb997">


## Additional Notes

Resolves #206, #207, #208, #197, #212, #232