### PR TITLE
added popup explanations for code analysis metrics

### DIFF
--- a/multi-git-dashboard/src/components/code-analysis/CodeAnalysisOverview.tsx
+++ b/multi-git-dashboard/src/components/code-analysis/CodeAnalysisOverview.tsx
@@ -1,6 +1,18 @@
-import { convertPercentage, convertRating } from '@/lib/utils';
-import React from 'react';
-import { Grid, Card, Text, Title, Container, Center } from '@mantine/core';
+import {
+  convertPercentage,
+  convertRating,
+  metricExplanations,
+} from '@/lib/utils';
+import React, { useState } from 'react';
+import {
+  Grid,
+  Card,
+  Text,
+  Title,
+  Container,
+  Center,
+  Tooltip,
+} from '@mantine/core';
 
 interface CodeAnalysisOverviewProps {
   latestData: {
@@ -70,6 +82,8 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
   latestData,
   executedDate,
 }) => {
+  const [hoveredMetric, setHoveredMetric] = useState<string | null>(null);
+
   const security_rating_index = latestData.metrics.indexOf('security_rating');
   const security_rating =
     security_rating_index === -1
@@ -114,12 +128,26 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
       ? '-'
       : latestData.values[quality_gate_status_index];
 
+  const handleMouseEnter = (metric: string) => {
+    setHoveredMetric(metric);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredMetric(null);
+  };
+
   return (
     <Container>
       <Grid gutter="lg">
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Security</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('security_rating')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Security
+            </Title>
             <Text size="xl" fw={700} c={getColorForRating(security_rating)}>
               {security_rating}
             </Text>
@@ -127,7 +155,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Reliability</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('reliability_rating')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Reliability
+            </Title>
             <Text size="xl" fw={700} c={getColorForRating(reliability_rating)}>
               {reliability_rating}
             </Text>
@@ -135,7 +169,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Maintainability</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('sqale_rating')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Maintainability
+            </Title>
             <Text
               size="xl"
               fw={700}
@@ -147,7 +187,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Coverage</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('coverage')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Coverage
+            </Title>
             <Text size="xl" fw={700} c={getColorForCoverage(coverage)}>
               {coverage}
             </Text>
@@ -155,7 +201,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Duplications</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('duplicated_lines_density')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Duplications
+            </Title>
             <Text size="xl" fw={700} c={getColorForDuplication(duplication)}>
               {duplication}
             </Text>
@@ -163,7 +215,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={4}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Complexity</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('complexity')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Complexity
+            </Title>
             <Text
               size="xl"
               fw={700}
@@ -175,7 +233,13 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
         </Grid.Col>
         <Grid.Col span={12}>
           <Card padding="lg" shadow="sm" radius="md">
-            <Title order={5}>Quality Gate</Title>
+            <Title
+              order={5}
+              onMouseEnter={() => handleMouseEnter('alert_status')}
+              onMouseLeave={handleMouseLeave}
+            >
+              Quality Gate
+            </Title>
             <Text
               size="xl"
               fw={700}
@@ -196,6 +260,22 @@ const CodeAnalysisOverview: React.FC<CodeAnalysisOverviewProps> = ({
       <Center mt={5} style={{ fontSize: '12px' }}>
         As of {executedDate.toLocaleString()}
       </Center>
+
+      {hoveredMetric && metricExplanations[hoveredMetric] && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '20px',
+            left: '20px',
+            padding: '10px',
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: 'white',
+            borderRadius: '5px',
+          }}
+        >
+          <strong>{hoveredMetric}</strong>: {metricExplanations[hoveredMetric]}
+        </div>
+      )}
     </Container>
   );
 };

--- a/multi-git-dashboard/src/components/code-analysis/CodeAnalysisTimeline.tsx
+++ b/multi-git-dashboard/src/components/code-analysis/CodeAnalysisTimeline.tsx
@@ -1,3 +1,4 @@
+import { metricExplanations } from '@/lib/utils';
 import React, { useState } from 'react';
 import {
   LineChart,
@@ -40,6 +41,7 @@ const CodeAnalysisTimeline: React.FC<CodeAnalysisTimelineProps> = ({
   }
 
   const [domain, setDomain] = useState<string>('Complexity');
+  const [hoveredMetric, setHoveredMetric] = useState<string | null>(null);
 
   Object.keys(codeData).map(executionDate => {
     const dataPoint = codeData[executionDate];
@@ -84,6 +86,14 @@ const CodeAnalysisTimeline: React.FC<CodeAnalysisTimelineProps> = ({
     new Date(item.executionDate).toLocaleDateString()
   );
 
+  const handleMouseEnter = (metric: string) => {
+    setHoveredMetric(metric);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredMetric(null);
+  };
+
   return (
     <div>
       <label htmlFor="domain-select">Select Domain:</label>
@@ -109,8 +119,11 @@ const CodeAnalysisTimeline: React.FC<CodeAnalysisTimelineProps> = ({
           />
           <YAxis />
           <Tooltip />
-          <Legend />
-          {Object.keys(domainData[0] || {})
+          <Legend
+            onMouseEnter={({ value }) => handleMouseEnter(value)}
+            onMouseLeave={handleMouseLeave}
+          />
+         {Object.keys(domainData[0] || {})
             .filter(key => key !== 'executionDate')
             .map(metric => (
               <Line
@@ -121,6 +134,22 @@ const CodeAnalysisTimeline: React.FC<CodeAnalysisTimelineProps> = ({
               />
             ))}
         </LineChart>
+
+        {hoveredMetric && metricExplanations[hoveredMetric] && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '20px',
+            left: '20px',
+            padding: '10px',
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: 'white',
+            borderRadius: '5px',
+          }}
+        >
+          <strong>{hoveredMetric}</strong>: {metricExplanations[hoveredMetric]}
+        </div>
+      )}
       </ResponsiveContainer>
     </div>
   );

--- a/multi-git-dashboard/src/lib/utils.ts
+++ b/multi-git-dashboard/src/lib/utils.ts
@@ -95,3 +95,67 @@ export const tutorialContents = [
   'This is the PR view. Here you can see the PRs submitted by this each team member, and the details of each PR. You can also filter PRs by various criteria.',
   'You can drag the slider to change the week range of the analytics and PR views.',
 ];
+
+export const metricExplanations = {
+  complexity:
+    'Calculated based on the number of paths through the code. Whenever the control flow of a function splits, the complexity counter gets incremented by one. Each function has a minimum complexity of 1. This calculation varies slightly by language because keywords and functionalities do.',
+  cognitive_complexity: "How hard it is to understand the code's control flow.",
+  branch_coverage:
+    "On each line of code containing some boolean expressions, the condition coverage simply answers the following question: 'Has each boolean expression been evaluated both to true and false?'. This is the density of possible conditions in flow control structures that have been followed during unit tests execution.",
+  coverage:
+    'It is a mix of Line coverage and Condition coverage. Its goal is to provide an even more accurate answer to the following question: How much of the source code has been covered by the unit tests?',
+  line_coverage:
+    'On a given line of code, Line coverage simply answers the following question: Has this line of code been executed during the execution of the unit tests? It is the density of covered lines by unit tests.',
+  tests: 'Number of unit tests.',
+  uncovered_conditions:
+    'Number of conditions which are not covered by unit tests.',
+  uncovered_lines:
+    'Number of lines of code which are not covered by unit tests.',
+  test_execution_time: 'Time required to execute all the unit tests.',
+  test_errors: 'Number of unit tests that have failed.',
+  test_failures:
+    'Number of unit tests that have failed with an unexpected exception.',
+  test_success_density:
+    'Test success density = (Unit tests - (Unit test errors + Unit test failures)) / Unit tests * 100',
+  skipped_tests: 'Number of skipped unit tests.',
+  duplicated_blocks: 'Number of duplicated blocks of lines.',
+  duplicated_files: 'Number of files involved in duplications.',
+  duplicated_lines: 'Number of lines involved in duplications.',
+  duplicated_lines_density: 'Duplicated lines / lines * 100',
+  code_smells: 'Total count of Code Smell issues.',
+  sqale_index:
+    'Effort to fix all Code Smells. The measure is stored in minutes in the database. An 8-hour day is assumed when values are shown in days. Uses SQALE Index.',
+  sqale_debt_ratio:
+    'Ratio between the cost to develop the software and the cost to fix it. The Technical Debt Ratio formula is: Remediation cost / Development cost.',
+  sqale_rating:
+    'Rating given to your project related to the value of your Technical Debt Ratio.',
+
+  alert_status:
+    'State of the Quality Gate associated to your Project. Possible values are: ERROR, OK. Your new code will be clean if: New code has 0 issues, All new security hotspots are reviewed, Coverage is greater than or equal to 80.0%, Duplicated Lines (%) is less than or equal to 3.0%',
+  quality_gate_details:
+    'For all the conditions of your Quality Gate, you know which condition is failing and which is not.',
+  bugs: 'Number of bug issues.',
+  reliability_rating:
+    'A= 0 Bugs, B= at least 1 Minor Bug, C= at least 1 Major Bug, D= at least 1 Critical Bug, E= at least 1 Blocker Bug',
+  reliability_remediation_effort:
+    'Effort to fix all bug issues. The measure is stored in minutes in the DB. An 8-hour day is assumed when values are shown in days.',
+  vulnerabilities: 'Number of vulnerability issues.',
+  security_rating:
+    'A= 0 Vulnerabilities, B= at least 1 Minor Vulnerability, C= at least 1 Major Vulnerability, D= at least 1 Critical Vulnerability, E= at least 1 Blocker Vulnerability',
+  security_remediation_effort:
+    'Effort to fix all vulnerability issues. The measure is stored in minutes in the DB. An 8-hour day is assumed when values are shown in days.',
+  security_hotspots: 'Number of Security Hotspots.',
+  classes:
+    'Number of classes (including nested classes, interfaces, enums, and annotations).',
+  comment_lines:
+    'Number of lines containing either comment or commented-out code.',
+  comment_lines_density:
+    'Comment lines / (Lines of code + Comment lines) * 100',
+  files: 'Number of files.',
+  lines: 'Number of physical lines (number of carriage returns).',
+  ncloc:
+    'Number of physical lines that contain at least one character which is neither a whitespace nor a tabulation nor part of a comment.',
+  functions:
+    'Number of functions. Depending on the language, a function is either a function or a method or a paragraph.',
+  statements: 'Number of statements.',
+};


### PR DESCRIPTION
## Description

Added popups to explain metrics when hovered over.

## Changes

- CodeAnalysisOverview
- CodeAnalysisTimeline

## Screenshots (if applicable)

<img width="985" alt="Screenshot 2025-01-02 at 5 27 34 PM" src="https://github.com/user-attachments/assets/545f7093-f67d-4747-b233-06dedef2dd79" />


## Additional Notes

Include any additional comments or context.

Resolves #<issue_number>