### PR TITLE
Move onAssessmentUpdated Calls to Finally Block

### DIFF
--- a/multi-git-dashboard/src/components/views/AssessmentInternalForm.tsx
+++ b/multi-git-dashboard/src/components/views/AssessmentInternalForm.tsx
@@ -477,9 +477,10 @@ const AssessmentInternalForm: React.FC<AssessmentInternalFormProps> = ({
         return;
       }
       setIsReleaseModalOpen(false);
-      onAssessmentUpdated();
     } catch (error) {
       console.error('Error releasing form:', error);
+    } finally {
+      onAssessmentUpdated();
     }
   };
 
@@ -520,9 +521,10 @@ const AssessmentInternalForm: React.FC<AssessmentInternalFormProps> = ({
       }
 
       setIsRecallModalOpen(false);
-      onAssessmentUpdated();
     } catch (error) {
       console.error('Error recalling form:', error);
+    } finally {
+      onAssessmentUpdated();
     }
   };
 


### PR DESCRIPTION
Attempt to fix a bug where recall/release form does not update existing data client-side on dev server