### PR TITLE
Add course field into TeamData Model 

### DIFF
--- a/backend/jobs/codeAnalysisJob.ts
+++ b/backend/jobs/codeAnalysisJob.ts
@@ -512,6 +512,7 @@ const getMedianAndMeanCodeData = async (course: any) => {
 
   const codeAnalysisData = await codeAnalysisDataModel.find({
     gitHubOrgName: course.gitHubOrgName,
+    repoName: { $regex: `^${course.repoNameFilter}` },
     executionTime: {
       $gte: startOfDay,
       $lte: endOfDay,
@@ -519,7 +520,7 @@ const getMedianAndMeanCodeData = async (course: any) => {
   });
 
   console.log(
-    `Getting mean and median code analysis values for ${course.gitHubOrgName} - ${codeAnalysisData.length} records`
+    `Getting mean and median code analysis values for ${course.gitHubOrgName}, ${course.repoNameFilter} - ${codeAnalysisData.length} records`
   );
 
   if (codeAnalysisData.length === 0) return;

--- a/backend/jobs/githubJob.ts
+++ b/backend/jobs/githubJob.ts
@@ -9,7 +9,7 @@ import { Review, TeamContribution, TeamPR } from '@shared/types/TeamData';
 import cron from 'node-cron';
 import { App, Octokit } from 'octokit';
 import TeamData from '../models/TeamData';
-import { getGitHubApp, getTeamMembers } from '../utils/github';
+import { getGitHubApp } from '../utils/github';
 
 const fetchAndSaveTeamData = async () => {
   const app: App = getGitHubApp();
@@ -238,6 +238,7 @@ const getCourseData = async (octokit: Octokit, course: any) => {
     }
 
     const teamData = {
+      course: course._id,
       gitHubOrgName: gitHubOrgName.toLowerCase(),
       teamId: repo.id,
       repoName: repo.name,

--- a/backend/jobs/publicGithubJob.ts
+++ b/backend/jobs/publicGithubJob.ts
@@ -224,6 +224,7 @@ const getPublicCourseData = async (course: any) => {
 
       const teamData = {
         gitHubOrgName: owner.toLowerCase(),
+        course: course._id,
         teamId: repoData.data.id,
         repoName: repo,
         commits: commits.length,

--- a/backend/models/TeamData.ts
+++ b/backend/models/TeamData.ts
@@ -78,6 +78,7 @@ const milestoneSchema = new Schema<Milestone>(
 
 const teamDataSchema = new Schema<TeamData>({
   teamId: { type: Number, required: true },
+  course: { type: Schema.Types.ObjectId, ref: 'Course', required: true },
   gitHubOrgName: { type: String, required: true },
   repoName: { type: String, required: true },
   commits: { type: Number, required: true },

--- a/backend/services/githubService.ts
+++ b/backend/services/githubService.ts
@@ -74,18 +74,8 @@ export const getAuthorizedTeamDataByCourse = async (
       throw new NotFoundError('User is not authorized to view course');
     }
 
-    // Extract the owner names from the course's GitHub repo links
-    const ownersFromRepoLinks = (course.gitHubRepoLinks || []).map(repoUrl => {
-      const urlParts = (repoUrl as string).split('/');
-      return urlParts[3].toLowerCase(); // Get the 'owner' part of the URL in lowercase
-    });
-
-    // Query for team data based on gitHubOrgName or gitHubRepoLinks
     const teamDatas = await TeamDataModel.find({
-      $or: [
-        { gitHubOrgName: course.gitHubOrgName },
-        { gitHubOrgName: { $in: ownersFromRepoLinks } },
-      ],
+      course: courseId,
     });
 
     if (!teamDatas) {

--- a/backend/test/services/codeAnalysisService.test.ts
+++ b/backend/test/services/codeAnalysisService.test.ts
@@ -131,6 +131,7 @@ describe('codeAnalysisService', () => {
     const teamData1 = new TeamDataModel({
       teamId: 1,
       gitHubOrgName: 'org',
+      course: mockCourse._id,
       repoName: 'team1',
       teamContributions: {},
       teamPRs: [],
@@ -146,6 +147,7 @@ describe('codeAnalysisService', () => {
     const teamData2 = new TeamDataModel({
       teamId: 2,
       gitHubOrgName: 'org',
+      course: mockCourse._id,
       repoName: 'team2',
       teamContributions: {},
       teamPRs: [],
@@ -468,6 +470,7 @@ describe('codeAnalysisService', () => {
       const teamDataA = new TeamDataModel({
         teamId: 123,
         gitHubOrgName: 'NoCodeAnalysisDataOrg',
+        course: courseWithoutCodeAnalysisData._id,
         repoName: 'teamA',
         teamContributions: {},
         teamPRs: [],

--- a/backend/test/services/githubService.test.ts
+++ b/backend/test/services/githubService.test.ts
@@ -79,7 +79,7 @@ describe('gitHubService', () => {
     const teamData1 = new TeamDataModel({
       repoName: 'team1',
       gitHubOrgName: 'org',
-      courseId: mockFacultyCourseId,
+      course: mockCourse._id,
       teamContributions: [],
       pullRequests: 0,
       issues: 0,
@@ -89,7 +89,7 @@ describe('gitHubService', () => {
     const teamData2 = new TeamDataModel({
       repoName: 'team2',
       gitHubOrgName: 'org',
-      courseId: mockFacultyCourseId,
+      course: mockCourse._id,
       teamContributions: [],
       pullRequests: 0,
       issues: 0,

--- a/shared/types/TeamData.ts
+++ b/shared/types/TeamData.ts
@@ -1,3 +1,5 @@
+import { Course } from './Course';
+
 export interface TeamContribution {
   commits: number;
   createdIssues: number;
@@ -49,6 +51,7 @@ export interface Milestone {
 
 export interface TeamData {
   _id: string;
+  course: Course;
   gitHubOrgName: string;
   teamId: number;
   repoName: string;


### PR DESCRIPTION
## Description

Replace searching for TeamData by github organisation name with course Id. Prevents old repositories from showing up in new courses using the same github organisation as old courses.

## Changes

- Added course (objectID ref CourseModel) into TeamDataModel and SharedTeamDataModel
- GitHubController uses courseId to search for teamData instead of githuborgname
- Amended tests accordingly

## Screenshots (if applicable)

Include any relevant screenshots or GIFs that demonstrate your changes visually.

## Additional Notes

**MUST RUN GITHUBJOB AND PUBLICGITHUBJOB IMMEDIATELY WHEN FIRST DEPLOYING ON DEV AND PROD**
Otherwise, backend will throw error as older teamdatamodels do not have course field.

Resolves #288 