### PR TITLE
Add Telegram Notification Commands in Bot

### DIFF
--- a/backend/clients/telegramClient.ts
+++ b/backend/clients/telegramClient.ts
@@ -143,7 +143,11 @@ bot.command('changeSettings', async ctx => {
     return;
   }
 
-  if (typeStr !== SETTINGS_HOURLY && typeStr !== SETTINGS_DAILY && typeStr !== SETTINGS_WEEKLY) {
+  if (
+    typeStr !== SETTINGS_HOURLY &&
+    typeStr !== SETTINGS_DAILY &&
+    typeStr !== SETTINGS_WEEKLY
+  ) {
     await ctx.reply(SETTINGS_CMD_USAGE + SETTINGS_ERR_FIRST_FIELD);
     return;
   }
@@ -183,7 +187,10 @@ bot.command('changeSettings', async ctx => {
     return;
   }
   const notificationDay = Number(dayStr);
-  if (typeStr === SETTINGS_WEEKLY && (isNaN(notificationDay) || notificationDay < 1 || notificationDay > 7)) {
+  if (
+    typeStr === SETTINGS_WEEKLY &&
+    (isNaN(notificationDay) || notificationDay < 1 || notificationDay > 7)
+  ) {
     await ctx.reply(SETTINGS_CMD_USAGE + SETTINGS_ERR_INVALID_DAY);
     return;
   }

--- a/backend/clients/telegramClient.ts
+++ b/backend/clients/telegramClient.ts
@@ -121,10 +121,11 @@ const SETTINGS_ERR_INVALID_DAY =
 
 bot.command('changeSettings', async ctx => {
   //Configures user's notification settings
-  //Usage: /change-settings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>
+  //Usage: /changeSettings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>
   //Examples:
-  //  /change-settings weekly 16 2 => notifications pushed on Tuesday, at 4pm every week
-  //  /change-settings daily 8 => notifications pushed at 8am every day
+  //  /changeSettings weekly 16 2 => notifications pushed on Tuesday, at 4pm every week
+  //  /changeSettings daily 8 => notifications pushed at 8am every day
+  //  /changeSettings hourly => notifications pushed every hour
 
   const account = await AccountModel.findOne({
     telegramChatId: ctx.chat.id,

--- a/backend/clients/telegramClient.ts
+++ b/backend/clients/telegramClient.ts
@@ -108,7 +108,7 @@ const SETTINGS_HOURLY = 'hourly';
 const SETTINGS_DAILY = 'daily';
 const SETTINGS_WEEKLY = 'weekly';
 const SETTINGS_CMD_USAGE =
-  'Usage: /changeSettings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>';
+  'Usage: /changesettings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>';
 const SETTINGS_ERR_FIRST_FIELD = `\nIncorrect first field. Must be ${SETTINGS_HOURLY}, ${SETTINGS_DAILY} or ${SETTINGS_WEEKLY}.`;
 const SETTINGS_ERR_MISSING_HOUR =
   '\nMissing hour of the day to push notifications.';
@@ -119,13 +119,13 @@ const SETTINGS_ERR_MISSING_DAY =
 const SETTINGS_ERR_INVALID_DAY =
   '\nDay field is invalid. Input a number from 1 (Monday) to 7 (Sunday)';
 
-bot.command('changeSettings', async ctx => {
+bot.command('changesettings', async ctx => {
   //Configures user's notification settings
-  //Usage: /changeSettings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>
+  //Usage: /changesettings <hourly/daily/weekly> <hour of the day (24h format)> <1 (Monday) - 7 (Sunday)>
   //Examples:
-  //  /changeSettings weekly 16 2 => notifications pushed on Tuesday, at 4pm every week
-  //  /changeSettings daily 8 => notifications pushed at 8am every day
-  //  /changeSettings hourly => notifications pushed every hour
+  //  /changesettings weekly 16 2 => notifications pushed on Tuesday, at 4pm every week
+  //  /changesettings daily 8 => notifications pushed at 8am every day
+  //  /changesettings hourly => notifications pushed every hour
 
   const account = await AccountModel.findOne({
     telegramChatId: ctx.chat.id,


### PR DESCRIPTION
## Description

Added Telegram Bot commands to allow users to now configure their Telegram notification settings via Telegram without needing to use CRISP