### PR TITLE
Fix Submission Frontend Routing and Submission Drafts

### DIFF
--- a/backend/services/submissionService.ts
+++ b/backend/services/submissionService.ts
@@ -421,141 +421,195 @@ export const createSubmission = async (
 ): Promise<Submission> => {
   const assessment = await getAssessmentWithQuestions(assessmentId);
 
-  let user: User | null = null;
-  try {
-    user = await UserModel.findById(userId);
-    if (!user) {
-      throw new NotFoundError('Submission creator not found');
-    }
-  } catch (e) {
+  const user = await UserModel.findById(userId);
+  if (!user) {
     throw new NotFoundError('Submission creator not found');
   }
 
-  await validateSubmissionPeriod(assessment);
-  await validateAnswers(assessment, answers);
-  const selectedStudentIds = (
-    answers.find(
-      answer => answer.type === 'Team Member Selection Answer'
-    ) as TeamMemberSelectionAnswer
-  ).selectedUserIds;
+  // We always need a Team Member Selection Answer, even in a draft.
+  const tmsAnswer = answers.find(
+    ans => ans.type === 'Team Member Selection Answer'
+  ) as TeamMemberSelectionAnswer;
+
+  if (!tmsAnswer) {
+    throw new BadRequestError(
+      'A Team Member Selection Answer is required for all submissions (including drafts).'
+    );
+  }
+
+  // If isDraft, skip normal validation and scoring. Otherwise proceed as before.
+  if (!isDraft) {
+    // Only check if the assessment is open for submission if not a draft
+    await validateSubmissionPeriod(assessment);
+
+    // Run full validation on all answers (will throw if invalid).
+    await validateAnswers(assessment, answers);
+  }
+
+  // Check for uniqueness of selected members (optional to do for drafts; up to you)
+  const selectedStudentIds = tmsAnswer.selectedUserIds;
   await checkSubmissionUniqueness(assessment, user, selectedStudentIds);
 
   let totalScore = 0;
+  const scoredAnswers = [];
 
-  const scoredAnswers = await Promise.all(
-    answers.map(async answer => {
-      const questionId = assessment.questions.find(
+  if (isDraft) {
+    // Skip scoring: just store the answers with score = 0
+    for (const answer of answers) {
+      const question = assessment.questions.find(
+        q => q._id.toString() === answer.question.toString()
+      );
+      if (!question) continue;
+      const { Model, question: savedQuestion } = await getAnswerModelForTypeForCreation(answer.type, question._id.toString());
+      if (!Model) {
+        console.warn(`Question of type ${Model} not found`);
+        continue;
+      }
+      if (!savedQuestion) {
+        console.warn(`Question with ID ${answer.question} not found.`);
+        const newAnswer = new Model({
+          ...answer,
+          score: 0,
+        });
+        await newAnswer.save();
+        scoredAnswers.push(newAnswer);
+        continue;
+      }
+      const newAnswer = new Model({
+        ...answer,
+        score: 0,
+      });
+      await newAnswer.save();
+      scoredAnswers.push(newAnswer);
+    }
+  } else {
+    // If final, do normal scoring
+    for (const answer of answers) {
+      const question = assessment.questions.find(
         q => q._id.toString() === answer.question.toString()
       ); // Guaranteed by validateAnswers()
-
-      let question = null;
-      let SaveAnswerModel = null;
-
-      switch (answer.type) {
-        case 'Number Answer':
-          question = await NumberQuestionModel.findById(questionId);
-          SaveAnswerModel = NumberAnswerModel;
-          break;
-        case 'Scale Answer':
-          question = await ScaleQuestionModel.findById(questionId);
-          SaveAnswerModel = ScaleAnswerModel;
-          break;
-        case 'Multiple Choice Answer':
-          question = await MultipleChoiceQuestionModel.findById(questionId);
-          SaveAnswerModel = MultipleChoiceAnswerModel;
-          break;
-        case 'Multiple Response Answer':
-          question = await MultipleResponseQuestionModel.findById(questionId);
-          SaveAnswerModel = MultipleResponseAnswerModel;
-          break;
-        case 'Team Member Selection Answer':
-          question =
-            await TeamMemberSelectionQuestionModel.findById(questionId);
-          SaveAnswerModel = TeamMemberSelectionAnswerModel;
-          break;
-        case 'Date Answer':
-          question = await DateQuestionModel.findById(questionId);
-          SaveAnswerModel = DateAnswerModel;
-          break;
-        case 'Short Response Answer':
-          question = await ShortResponseQuestionModel.findById(questionId);
-          SaveAnswerModel = ShortResponseAnswerModel;
-          break;
-        case 'Long Response Answer':
-          question = await LongResponseQuestionModel.findById(questionId);
-          SaveAnswerModel = LongResponseAnswerModel;
-          break;
-        case 'Undecided Answer':
-        default:
-          question = await UndecidedQuestionModel.findById(questionId);
-          SaveAnswerModel = UndecidedAnswerModel;
-          break;
+      const { Model, question: savedQuestion } = await getAnswerModelForTypeForCreation(answer.type, question!._id.toString());
+      if (!Model) {
+        console.warn(`Question of type ${Model} not found`);
+        continue;
       }
-
-      if (!question) {
+      if (!savedQuestion) {
         console.warn(`Question with ID ${answer.question} not found.`);
-        return { ...answer, score: 0 };
+        const newAnswer = new Model({
+          ...answer,
+          score: 0,
+        });
+        await newAnswer.save();
+        scoredAnswers.push(newAnswer);
+        continue;
       }
-
       const answerScore = await calculateAnswerScore(
-        question,
+        savedQuestion,
         answer,
         assessment
       );
       totalScore += answerScore;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { type, ...scoredAnswer } = { ...answer, score: answerScore };
 
-      const newAnswer = new SaveAnswerModel(scoredAnswer);
+      const newAnswer = new Model({
+        ...answer,
+        score: answerScore,
+      });
       await newAnswer.save();
-      return newAnswer;
-    })
-  );
+      scoredAnswers.push(newAnswer);
+    }
+  }
 
-  const assignment = answers.find(
-    answer => answer.type === 'Team Member Selection Answer'
-  ) as TeamMemberSelectionAnswer;
-
+  // Create the submission document
   const submission = new SubmissionModel({
     assessment: assessmentId,
     user: userId,
     answers: scoredAnswers,
     isDraft,
     submittedAt: new Date(),
-    score: totalScore,
+    score: isDraft ? 0 : totalScore, // If draft => 0, else => totalScore
     submissionReleaseNumber: assessment.releaseNumber,
   });
-
   await submission.save();
-  for (const userId of assignment.selectedUserIds) {
-    let assessmentResult = await AssessmentResultModel.findOne({
-      assessment: assessmentId,
-      student: userId,
-    });
 
-    if (!assessmentResult) {
-      assessmentResult = new AssessmentResultModel({
+  // If it is not a draft, update the AssessmentResult for each selected user
+  if (!isDraft) {
+    for (const selUserId of selectedStudentIds) {
+      let assessmentResult = await AssessmentResultModel.findOne({
         assessment: assessmentId,
-        student: userId,
-        marks: [],
-        averageScore: 0,
+        student: selUserId,
       });
 
-      await assessmentResult.save();
-    }
-    const newMarkEntry: MarkEntry = {
-      marker: user,
-      submission: submission._id,
-      score: totalScore,
-    };
-    assessmentResult.marks.push(newMarkEntry);
-    await assessmentResult.save();
+      if (!assessmentResult) {
+        assessmentResult = new AssessmentResultModel({
+          assessment: assessmentId,
+          student: selUserId,
+          marks: [],
+          averageScore: 0,
+        });
+        await assessmentResult.save();
+      }
 
-    await recalculateResult(assessmentResult.id);
+      const newMarkEntry: MarkEntry = {
+        marker: user,
+        submission: submission._id,
+        score: totalScore,
+      };
+      assessmentResult.marks.push(newMarkEntry);
+      await assessmentResult.save();
+
+      await recalculateResult(assessmentResult.id);
+    }
   }
 
   return submission;
 };
+
+/**
+ * A small helper to get the correct Mongoose model for each answer type.
+ */
+async function getAnswerModelForTypeForCreation(type: string, questionId: string) {
+  let question = null;
+  let Model = null;
+  switch (type) {
+    case 'Number Answer':
+      question = await NumberQuestionModel.findById(questionId);
+      Model = NumberAnswerModel;
+      return { Model, question };
+    case 'Scale Answer':
+      question = await ScaleQuestionModel.findById(questionId);
+      Model = ScaleAnswerModel;
+      return { Model, question };
+    case 'Multiple Choice Answer':
+      question = await MultipleChoiceQuestionModel.findById(questionId);
+      Model = MultipleChoiceAnswerModel;
+      return { Model, question };
+    case 'Multiple Response Answer':
+      question = await MultipleResponseQuestionModel.findById(questionId);
+      Model = MultipleResponseAnswerModel;
+      return { Model, question };
+    case 'Team Member Selection Answer':
+      question =
+        await TeamMemberSelectionQuestionModel.findById(questionId);
+        Model = TeamMemberSelectionAnswerModel;
+      return { Model, question };
+    case 'Date Answer':
+      question = await DateQuestionModel.findById(questionId);
+      Model = DateAnswerModel;
+      return { Model, question };
+    case 'Short Response Answer':
+      question = await ShortResponseQuestionModel.findById(questionId);
+      Model = ShortResponseAnswerModel;
+      return { Model, question };
+    case 'Long Response Answer':
+      question = await LongResponseQuestionModel.findById(questionId);
+      Model = LongResponseAnswerModel;
+      return { Model, question };
+    default:
+      question = await UndecidedQuestionModel.findById(questionId);
+      Model = UndecidedAnswerModel;
+      return { Model, question };
+  }
+}
 
 /**
  * Updates an existing submission by its ID.
@@ -608,8 +662,6 @@ export const updateSubmission = async (
   if (!course) throw new BadRequestError('Assessment course id invalid');
   const isCourseFaculty =
     course.faculty.filter(f => f === account!.user).length !== 0;
-  // Alternative method would be to check if account's .courseRole
-  // contains this course and has faculty role in the same tuple.
   if (account && (isCourseFaculty || account.crispRole === CrispRole.Admin)) {
     bypass = true;
   }
@@ -620,8 +672,32 @@ export const updateSubmission = async (
     );
   }
 
-  await validateSubmissionPeriod(assessment);
-  await validateAnswers(assessment, answers);
+  const assignment = answers.find(
+    ans => ans.type === 'Team Member Selection Answer'
+  ) as TeamMemberSelectionAnswer;
+  if (!assignment) {
+    throw new BadRequestError('Team Member Selection Answer is required');
+  }
+
+  const savedAssignment = submission.answers.find(
+    ans => ans.type === 'Team Member Selection Answer'
+  ) as TeamMemberSelectionAnswer;
+  if (!savedAssignment) {
+    console.warn('Original Submission missing Team Member Selection Answer');
+  }
+
+  if (savedAssignment) {
+    for (const memberId of assignment.selectedUserIds) {
+      if (!savedAssignment.toObject().selectedUserIds.some((uid: string) => uid !== memberId)) {// .selectedUserId is undefined here
+        throw new BadRequestError('Selected team/users should not change');
+      }
+    }
+  }
+
+  if (!isDraft) {
+    await validateSubmissionPeriod(assessment);
+    await validateAnswers(assessment, answers);
+  }
 
   if (
     !bypass &&
@@ -634,83 +710,55 @@ export const updateSubmission = async (
     );
   }
 
+  // Always re-grade to get the latest score in submission.score,
+  // even if isDraft == true
   let totalScore = 0;
 
   await Promise.all(
     answers.map(async answer => {
-      const questionId = assessment.questions.find(
+      const question = assessment.questions.find(
         q => q._id.toString() === answer.question.toString()
-      ); // Question Id exists, verified by validateAnswers()
-
-      let question = null;
-      let savedAnswer = null;
-
-      switch (answer.type) {
-        case 'Number Answer':
-          question = await NumberQuestionModel.findById(questionId);
-          savedAnswer = NumberAnswerModel.findById(answer.id);
-          break;
-        case 'Scale Answer':
-          question = await ScaleQuestionModel.findById(questionId);
-          savedAnswer = ScaleAnswerModel.findById(answer.id);
-          break;
-        case 'Multiple Choice Answer':
-          question = await MultipleChoiceQuestionModel.findById(questionId);
-          savedAnswer = MultipleChoiceAnswerModel.findById(answer.id);
-          break;
-        case 'Multiple Response Answer':
-          question = await MultipleResponseQuestionModel.findById(questionId);
-          savedAnswer = MultipleResponseAnswerModel.findById(answer.id);
-          break;
-        case 'Team Member Selection Answer':
-          question =
-            await TeamMemberSelectionQuestionModel.findById(questionId);
-          savedAnswer = TeamMemberSelectionAnswerModel.findById(answer.id);
-          break;
-        case 'Date Answer':
-          question = await DateQuestionModel.findById(questionId);
-          savedAnswer = DateAnswerModel.findById(answer.id);
-          break;
-        case 'Short Response Answer':
-          question = await ShortResponseQuestionModel.findById(questionId);
-          savedAnswer = ShortResponseAnswerModel.findById(answer.id);
-          break;
-        case 'Long Response Answer':
-          question = await LongResponseQuestionModel.findById(questionId);
-          savedAnswer = LongResponseAnswerModel.findById(answer.id);
-          break;
-        case 'Undecided Answer':
-        default:
-          question = await UndecidedQuestionModel.findById(questionId);
-          savedAnswer = UndecidedAnswerModel.findById(answer.id);
-          break;
-      }
+      );
 
       if (!question) {
         console.warn(
           `Question with ID ${answer.question} not found in assessment ${assessment.id}.`
         );
+        // Just store 0 if the question doesn't exist
         answer.score = 0;
         return;
       }
+      const questionId = question._id;
 
-      const answerScore = await calculateAnswerScore(
-        question,
-        answer,
-        assessment
-      );
+      // Re-grade
+      const questionDoc = await getQuestionDoc(questionId.toString(), answer.type);
+      if (!questionDoc) {
+        console.warn(
+          `Mismatched question or doc not found for question ${questionId}`
+        );
+        answer.score = 0;
+        return;
+      }
+      const savedAnswer = getAnswerModelForTypeForUpdate(answer.type, answer._id);
+      if (!savedAnswer) {
+        console.warn(`Answer type ${savedAnswer} not found`);
+        return;
+      }
+      const answerScore = await calculateAnswerScore(questionDoc, answer, assessment);
       totalScore += answerScore;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { type, ...scoredAnswer } = { ...answer, score: answerScore };
 
+      // Save the updated answer doc (with new score)
       answer.score = answerScore;
-      savedAnswer.model.findByIdAndUpdate(answer._id, answer);
+      await savedAnswer.model.findByIdAndUpdate(answer._id, answer);
     })
   );
 
+  // Update the submission object itself
   submission.answers = answers;
   submission.isDraft = isDraft;
   submission.submittedAt = new Date();
+
+  // If the total score changed, reset any manual adjustedScore
   if (submission.score !== totalScore) {
     submission.score = totalScore;
     submission.adjustedScore = undefined;
@@ -719,44 +767,108 @@ export const updateSubmission = async (
 
   await submission.save();
 
-  const assignment = answers.find(
-    answer => answer.type === 'Team Member Selection Answer'
-  ) as TeamMemberSelectionAnswer;
+  if (!isDraft && assignment) {
+    for (const selectedUserId of assignment.selectedUserIds) {
+      const assessmentResult = await AssessmentResultModel.findOne({
+        assessment: assessment._id,
+        student: selectedUserId,
+      });
 
-  for (const selectedUserId of assignment.selectedUserIds) {
-    console.log(selectedUserId, assessment._id);
-    const assessmentResult = await AssessmentResultModel.findOne({
-      assessment: assessment._id,
-      student: selectedUserId,
-    });
+      if (!assessmentResult) {
+        // If no existing result, create it
+        const newResult = new AssessmentResultModel({
+          assessment: assessment._id,
+          student: selectedUserId,
+          marks: [
+            {
+              marker: user,
+              submission: submission._id,
+              score: totalScore,
+            },
+          ],
+          averageScore: 0,
+        });
+        await newResult.save();
+        await recalculateResult(newResult.id);
+      } else {
+        // Update an existing mark entry or add a new one
+        const markEntryIndex = assessmentResult.marks.findIndex(
+          mark => mark.submission.toString() === submission._id.toString()
+        );
 
-    if (!assessmentResult) {
-      throw new NotFoundError(
-        'No previous assessment result found. Something went wrong with the flow.'
-      );
+        if (markEntryIndex !== -1) {
+          assessmentResult.marks[markEntryIndex].marker = user;
+          assessmentResult.marks[markEntryIndex].score = totalScore;
+        } else {
+          // If no MarkEntry yet, push a new one
+          assessmentResult.marks.push({
+            marker: user,
+            submission: submission._id,
+            score: totalScore,
+          });
+        }
+        await assessmentResult.save();
+        await recalculateResult(assessmentResult.id);
+      }
     }
-
-    // Find existing mark entry for this submission
-    const markEntryIndex = assessmentResult.marks.findIndex(
-      mark => mark.submission.toString() === submission._id.toString()
-    );
-
-    if (markEntryIndex !== -1) {
-      assessmentResult.marks[markEntryIndex].marker = user;
-      assessmentResult.marks[markEntryIndex].score = totalScore;
-    } else {
-      throw new NotFoundError(
-        'Mark entry for this submission not found in assessment result.'
-      );
-    }
-
-    await assessmentResult.save();
-
-    await recalculateResult(assessmentResult.id);
   }
 
   return submission;
 };
+
+/**
+ * Simple utility that returns the correct question doc from the DB
+ * given the question id and answer type.
+ */
+async function getQuestionDoc(questionId: QuestionUnion | string, answerType: string) {
+  switch (answerType) {
+    case 'Number Answer':
+      return NumberQuestionModel.findById(questionId);
+    case 'Scale Answer':
+      return ScaleQuestionModel.findById(questionId);
+    case 'Multiple Choice Answer':
+      return MultipleChoiceQuestionModel.findById(questionId);
+    case 'Multiple Response Answer':
+      return MultipleResponseQuestionModel.findById(questionId);
+    case 'Team Member Selection Answer':
+      return TeamMemberSelectionQuestionModel.findById(questionId);
+    case 'Date Answer':
+      return DateQuestionModel.findById(questionId);
+    case 'Short Response Answer':
+      return ShortResponseQuestionModel.findById(questionId);
+    case 'Long Response Answer':
+      return LongResponseQuestionModel.findById(questionId);
+    default:
+      return UndecidedQuestionModel.findById(questionId);
+  }
+}
+
+/**
+ * Simple utility that returns the correct Answer Model for creation / updates.
+ */
+function getAnswerModelForTypeForUpdate(answerType: string, answerId: string) {
+  switch (answerType) {
+    case 'Number Answer':
+      return NumberAnswerModel.findById(answerId);
+    case 'Scale Answer':
+      return ScaleAnswerModel.findById(answerId);
+    case 'Multiple Choice Answer':
+      return MultipleChoiceAnswerModel.findById(answerId);
+    case 'Multiple Response Answer':
+      return MultipleResponseAnswerModel.findById(answerId);
+    case 'Team Member Selection Answer':
+      return TeamMemberSelectionAnswerModel.findById(answerId);
+    case 'Date Answer':
+      return DateAnswerModel.findById(answerId);
+    case 'Short Response Answer':
+      return ShortResponseAnswerModel.findById(answerId);
+    case 'Long Response Answer':
+      return LongResponseAnswerModel.findById(answerId);
+    default:
+      return UndecidedAnswerModel.findById(answerId);
+  }
+}
+
 
 /**
  * Retrieves all submissions by a single user for a specific assessment.

--- a/backend/services/submissionService.ts
+++ b/backend/services/submissionService.ts
@@ -460,7 +460,11 @@ export const createSubmission = async (
         q => q._id.toString() === answer.question.toString()
       );
       if (!question) continue;
-      const { Model, question: savedQuestion } = await getAnswerModelForTypeForCreation(answer.type, question._id.toString());
+      const { Model, question: savedQuestion } =
+        await getAnswerModelForTypeForCreation(
+          answer.type,
+          question._id.toString()
+        );
       if (!Model) {
         console.warn(`Question of type ${Model} not found`);
         continue;
@@ -488,7 +492,11 @@ export const createSubmission = async (
       const question = assessment.questions.find(
         q => q._id.toString() === answer.question.toString()
       ); // Guaranteed by validateAnswers()
-      const { Model, question: savedQuestion } = await getAnswerModelForTypeForCreation(answer.type, question!._id.toString());
+      const { Model, question: savedQuestion } =
+        await getAnswerModelForTypeForCreation(
+          answer.type,
+          question!._id.toString()
+        );
       if (!Model) {
         console.warn(`Question of type ${Model} not found`);
         continue;
@@ -567,7 +575,10 @@ export const createSubmission = async (
 /**
  * A small helper to get the correct Mongoose model for each answer type.
  */
-async function getAnswerModelForTypeForCreation(type: string, questionId: string) {
+async function getAnswerModelForTypeForCreation(
+  type: string,
+  questionId: string
+) {
   let question = null;
   let Model = null;
   switch (type) {
@@ -588,9 +599,8 @@ async function getAnswerModelForTypeForCreation(type: string, questionId: string
       Model = MultipleResponseAnswerModel;
       return { Model, question };
     case 'Team Member Selection Answer':
-      question =
-        await TeamMemberSelectionQuestionModel.findById(questionId);
-        Model = TeamMemberSelectionAnswerModel;
+      question = await TeamMemberSelectionQuestionModel.findById(questionId);
+      Model = TeamMemberSelectionAnswerModel;
       return { Model, question };
     case 'Date Answer':
       question = await DateQuestionModel.findById(questionId);
@@ -688,7 +698,12 @@ export const updateSubmission = async (
 
   if (savedAssignment) {
     for (const memberId of assignment.selectedUserIds) {
-      if (!savedAssignment.toObject().selectedUserIds.some((uid: string) => uid !== memberId)) {// .selectedUserId is undefined here
+      if (
+        !savedAssignment
+          .toObject()
+          .selectedUserIds.some((uid: string) => uid !== memberId)
+      ) {
+        // .selectedUserId is undefined here
         throw new BadRequestError('Selected team/users should not change');
       }
     }
@@ -731,7 +746,10 @@ export const updateSubmission = async (
       const questionId = question._id;
 
       // Re-grade
-      const questionDoc = await getQuestionDoc(questionId.toString(), answer.type);
+      const questionDoc = await getQuestionDoc(
+        questionId.toString(),
+        answer.type
+      );
       if (!questionDoc) {
         console.warn(
           `Mismatched question or doc not found for question ${questionId}`
@@ -739,12 +757,19 @@ export const updateSubmission = async (
         answer.score = 0;
         return;
       }
-      const savedAnswer = getAnswerModelForTypeForUpdate(answer.type, answer._id);
+      const savedAnswer = getAnswerModelForTypeForUpdate(
+        answer.type,
+        answer._id
+      );
       if (!savedAnswer) {
         console.warn(`Answer type ${savedAnswer} not found`);
         return;
       }
-      const answerScore = await calculateAnswerScore(questionDoc, answer, assessment);
+      const answerScore = await calculateAnswerScore(
+        questionDoc,
+        answer,
+        assessment
+      );
       totalScore += answerScore;
 
       // Save the updated answer doc (with new score)
@@ -820,7 +845,10 @@ export const updateSubmission = async (
  * Simple utility that returns the correct question doc from the DB
  * given the question id and answer type.
  */
-async function getQuestionDoc(questionId: QuestionUnion | string, answerType: string) {
+async function getQuestionDoc(
+  questionId: QuestionUnion | string,
+  answerType: string
+) {
   switch (answerType) {
     case 'Number Answer':
       return NumberQuestionModel.findById(questionId);
@@ -868,7 +896,6 @@ function getAnswerModelForTypeForUpdate(answerType: string, answerId: string) {
       return UndecidedAnswerModel.findById(answerId);
   }
 }
-
 
 /**
  * Retrieves all submissions by a single user for a specific assessment.

--- a/multi-git-dashboard/src/components/Navbar.tsx
+++ b/multi-git-dashboard/src/components/Navbar.tsx
@@ -157,14 +157,14 @@ const Navbar: React.FC = () => {
       return 'Assessments';
     } else if (path.startsWith('/courses/[id]/project-management')) {
       return 'Project Management';
-    } else if (path.startsWith('/courses/[id]/class-review')) {
-      return 'Class Review';
+    } else if (path.startsWith('/courses/[id]/class-overview')) {
+      return 'Class Overview';
     } else if (path.startsWith('/courses/[id]/code-analysis')) {
       return 'Code Analysis';
     } else if (path.startsWith('/courses/[id]/pr-review')) {
       return 'PR Review';
     } else if (path.startsWith('/courses/[id]')) {
-      return 'Team Overview';
+      return 'Team Review';
     } else {
       return '';
     }

--- a/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
+++ b/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
@@ -33,6 +33,7 @@ interface AssessmentInternalOverviewProps {
   initialAssignedTeams?: AssignedTeam[];
   initialAssignedUsers?: AssignedUser[];
   teachingStaff: User[];
+  onTakeAssessmentClicked: () => void;
 }
 
 const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
@@ -45,6 +46,7 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
   initialAssignedTeams = [],
   initialAssignedUsers = [],
   teachingStaff,
+  onTakeAssessmentClicked,
 }) => {
   const [submissions, setSubmissions] = useState<Submission[]>([]);
   const [assignedTeams, setAssignedTeams] =
@@ -485,14 +487,12 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
             <strong>End Date:</strong> {formatDate(assessment?.endDate)}
           </Text>
         </Group>
-        {assessment?.isReleased && (
+        {assessment && assessment.isReleased && (
           <Group justify="center" mt="md">
             {assignedEntitiesAvailable ? (
               <Button
                 onClick={() =>
-                  router.push(
-                    `/courses/${courseId}/internal-assessments/${assessment?._id}/take`
-                  )
+                  onTakeAssessmentClicked()
                 }
               >
                 Submit Assessment

--- a/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
+++ b/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
@@ -76,6 +76,11 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
   const router = useRouter();
   const deleteInternalAssessmentApiRoute = `/api/internal-assessments/${assessment?._id}`;
 
+  const hasDraftSubmissions = useMemo(
+    () => submissions.some(sub => sub.isDraft),
+    [submissions]
+  );
+
   const formatDate = (date: Date | string | undefined) => {
     if (!date) return 'N/A';
     const d = new Date(date);
@@ -120,12 +125,7 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
         return;
       }
 
-      let data: Submission[] = await response.json();
-
-      // For faculty, filter out drafts
-      if (hasFacultyPermission) {
-        data = data.filter(submission => !submission.isDraft);
-      }
+      const data: Submission[] = await response.json();
 
       setSubmissions(data);
     } catch (error) {
@@ -374,8 +374,6 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
         );
         return;
       }
-      const data = await response.json();
-      console.log('TA assignments saved successfully:', data);
       toggleTeamAssignmentModal();
     } catch (error) {
       console.error('Error saving TA assignments:', error);
@@ -490,15 +488,17 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
         {assessment && assessment.isReleased && (
           <Group justify="center" mt="md">
             {assignedEntitiesAvailable ? (
-              <Button
-                onClick={() =>
-                  onTakeAssessmentClicked()
-                }
-              >
+              <Button onClick={() => onTakeAssessmentClicked()}>
                 Submit Assessment
               </Button>
+            ) : hasDraftSubmissions ? (
+              <Text c="dimmed">
+                Pending submission drafts only; no remaining teams or users await new submissions.
+              </Text>
             ) : (
-              <Text c="dimmed">All assigned teams/users have been graded</Text>
+              <Text c="dimmed">
+                All assigned teams/users have been graded
+              </Text>
             )}
           </Group>
         )}

--- a/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
+++ b/multi-git-dashboard/src/components/views/AssessmentInternalOverview.tsx
@@ -493,12 +493,11 @@ const AssessmentInternalOverview: React.FC<AssessmentInternalOverviewProps> = ({
               </Button>
             ) : hasDraftSubmissions ? (
               <Text c="dimmed">
-                Pending submission drafts only; no remaining teams or users await new submissions.
+                Pending submission drafts only; no remaining teams or users
+                await new submissions.
               </Text>
             ) : (
-              <Text c="dimmed">
-                All assigned teams/users have been graded
-              </Text>
+              <Text c="dimmed">All assigned teams/users have been graded</Text>
             )}
           </Group>
         )}

--- a/multi-git-dashboard/src/components/views/EditAssessment.tsx
+++ b/multi-git-dashboard/src/components/views/EditAssessment.tsx
@@ -30,6 +30,7 @@ import { Submission } from '@shared/types/Submission';
 import TakeAssessmentCard from '@/components/cards/TakeAssessmentCard';
 import { Team } from '@shared/types/Team';
 import { User } from '@shared/types/User';
+import { isTrial } from '@/lib/auth/utils';
 
 interface EditAssessmentProps {
   inputAssessment: InternalAssessment;
@@ -91,7 +92,7 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
   const [newAdjustedScore, setNewAdjustedScore] = useState<number | undefined>(
     undefined
   );
-  const [isTrial, setIsTrial] = useState<boolean>(false);
+  const isTrialVar = isTrial();
 
   const isScoredQuestion = (
     question: QuestionUnion
@@ -221,8 +222,6 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
           })),
         }));
         setTeamOptions(options);
-        if (teams[0].TA.identifier === process.env.TRIAL_USER_ID)
-          setIsTrial(true);
       } else if (assessment.granularity === 'individual') {
         const users = data as User[];
         const options = users.map(user => ({
@@ -230,9 +229,6 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
           label: user.name,
         }));
         setTeamMembersOptions(options);
-        // There is no equivalent method for users for checking trial since
-        // Users don't have TA info. If you want that, you need to add
-        // a new method just to check if current user is a trial user.
       }
     } catch (error) {
       console.error('Error fetching assigned entities:', error);
@@ -629,7 +625,7 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
         message: 'Your draft submission has been deleted.',
         color: 'red',
       });
-      router.back();
+      router.push(`/courses/${id}/internal-assessments/${assessmentId}`);
     } catch (error) {
       console.error('Error deleting draft submission:', error);
       showNotification({
@@ -811,7 +807,7 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
                 Delete Draft
               </Button>
             )}
-            {(!submission || submission.isDraft) && false && (
+            {(!submission || submission.isDraft) && (
               <Button variant="default" onClick={handleSaveDraft}>
                 Save Draft
               </Button>
@@ -820,7 +816,7 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
               onClick={handleSubmitClick}
               loading={isSubmitting}
               disabled={
-                (!canEdit && !(submission && submission.isDraft)) || isTrial
+                (!canEdit && !(submission && submission.isDraft)) || isTrialVar
               }
               variant={
                 canEdit || (submission && submission.isDraft)
@@ -834,7 +830,7 @@ const EditAssessment: React.FC<EditAssessmentProps> = ({
         </Group>
       )}
 
-      {isFaculty && submission && (
+      {isFaculty && submission && !submission.isDraft && (
         <Paper shadow="sm" p="md" mt="xl" withBorder>
           <Group justify="flex-end" align="center" mb="md">
             <Text size="lg">Submission Score</Text>

--- a/multi-git-dashboard/src/components/views/EditAssessment.tsx
+++ b/multi-git-dashboard/src/components/views/EditAssessment.tsx
@@ -31,14 +31,14 @@ import TakeAssessmentCard from '@/components/cards/TakeAssessmentCard';
 import { Team } from '@shared/types/Team';
 import { User } from '@shared/types/User';
 
-interface TakeAssessmentProps {
+interface EditAssessmentProps {
   inputAssessment: InternalAssessment;
   existingSubmission?: Submission;
   canEdit?: boolean;
   isFaculty?: boolean;
 }
 
-const TakeAssessment: React.FC<TakeAssessmentProps> = ({
+const EditAssessment: React.FC<EditAssessmentProps> = ({
   inputAssessment,
   existingSubmission,
   canEdit = true,
@@ -223,7 +223,6 @@ const TakeAssessment: React.FC<TakeAssessmentProps> = ({
         setTeamOptions(options);
         if (teams[0].TA.identifier === process.env.TRIAL_USER_ID)
           setIsTrial(true);
-        console.log(teams, isTrial);
       } else if (assessment.granularity === 'individual') {
         const users = data as User[];
         const options = users.map(user => ({
@@ -1026,4 +1025,4 @@ const TakeAssessment: React.FC<TakeAssessmentProps> = ({
   );
 };
 
-export default TakeAssessment;
+export default EditAssessment;

--- a/multi-git-dashboard/src/components/views/TakeAssessmentInline.tsx
+++ b/multi-git-dashboard/src/components/views/TakeAssessmentInline.tsx
@@ -1,12 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* Example file: components/views/TakeAssessmentInline.tsx */
 
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  Fragment
-} from 'react';
+import React, { useState, useEffect, useCallback, Fragment } from 'react';
 import {
   Container,
   Button,
@@ -27,9 +22,7 @@ import {
   ScaleQuestion,
   NumberQuestion,
 } from '@shared/types/Question';
-import {
-  AnswerUnion
-} from '@shared/types/Answer';
+import { AnswerUnion } from '@shared/types/Answer';
 import { AnswerInput } from '@shared/types/AnswerInput';
 import { Submission } from '@shared/types/Submission';
 import { User } from '@shared/types/User';
@@ -51,20 +44,29 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
   const router = useRouter();
   const [assessment, setAssessment] = useState<InternalAssessment | null>(null);
   const [questions, setQuestions] = useState<Question[]>([]);
-  const [answers, setAnswers] = useState<{ [questionId: string]: AnswerInput }>({});
+  const [answers, setAnswers] = useState<{ [questionId: string]: AnswerInput }>(
+    {}
+  );
   const [submission, setSubmission] = useState<Submission | undefined>();
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [showConfirmationModal, setShowConfirmationModal] = useState<boolean>(false);
-  const [missingRequiredQuestions, setMissingRequiredQuestions] = useState<string[]>([]);
+  const [showConfirmationModal, setShowConfirmationModal] =
+    useState<boolean>(false);
+  const [missingRequiredQuestions, setMissingRequiredQuestions] = useState<
+    string[]
+  >([]);
   const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
 
-  const [showAdjustScoreModal, setShowAdjustScoreModal] = useState<boolean>(false);
-  const [newAdjustedScore, setNewAdjustedScore] = useState<number | undefined>(undefined);
+  const [showAdjustScoreModal, setShowAdjustScoreModal] =
+    useState<boolean>(false);
+  const [newAdjustedScore, setNewAdjustedScore] = useState<number | undefined>(
+    undefined
+  );
 
   const [showSummaryModal, setShowSummaryModal] = useState<boolean>(false);
   const [showBackModal, setShowBackModal] = useState<boolean>(false);
-  const [showDeleteDraftModal, setShowDeleteDraftModal] = useState<boolean>(false);
+  const [showDeleteDraftModal, setShowDeleteDraftModal] =
+    useState<boolean>(false);
 
   const [teamOptions, setTeamOptions] = useState<
     {
@@ -88,12 +90,16 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
   // =========== UTILS =============
   const isScoredQuestion = (
     question: QuestionUnion
-  ): question is MultipleChoiceQuestion | MultipleResponseQuestion | ScaleQuestion | NumberQuestion => {
+  ): question is
+    | MultipleChoiceQuestion
+    | MultipleResponseQuestion
+    | ScaleQuestion
+    | NumberQuestion => {
     return (
       (question.type === 'Multiple Choice' ||
-       question.type === 'Multiple Response' ||
-       question.type === 'Scale' ||
-       question.type === 'Number') &&
+        question.type === 'Multiple Response' ||
+        question.type === 'Scale' ||
+        question.type === 'Number') &&
       question.isScored
     );
   };
@@ -255,7 +261,8 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
             const selectedNames = selectedMembers
               .map(
                 id =>
-                  teamMembersOptions.find(option => option.value === id)?.label || id
+                  teamMembersOptions.find(option => option.value === id)
+                    ?.label || id
               )
               .join(', ');
             return selectedNames;
@@ -286,7 +293,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       showNotification({
         title: 'Error',
         message: 'Failed to load assessment data.',
-        color: 'red'
+        color: 'red',
       });
     }
   }, [assessment, assessmentApiRoute]);
@@ -304,7 +311,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       showNotification({
         title: 'Error',
         message: 'Failed to load questions.',
-        color: 'red'
+        color: 'red',
       });
     }
   }, [questionsApiRoute]);
@@ -324,7 +331,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
         const options = teams.map(team => ({
           value: team._id,
           label: `Team ${team.number}`,
-          members: team.members.map((member: { _id: any; name: any; }) => ({
+          members: team.members.map((member: { _id: any; name: any }) => ({
             value: member._id,
             label: member.name,
           })),
@@ -343,7 +350,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       showNotification({
         title: 'Error',
         message: 'Failed to load assigned data.',
-        color: 'red'
+        color: 'red',
       });
     }
   }, [assessment, assignedEntitiesApiRoute]);
@@ -495,7 +502,9 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       // Return to overview
       onReturnToOverview();
 
-      router.push(`/courses/${courseId}/internal-assessments/${assessmentId}/submission/${savedSubmission._id}`);
+      router.push(
+        `/courses/${courseId}/internal-assessments/${assessmentId}/submission/${savedSubmission._id}`
+      );
     } catch (err) {
       console.error(err);
       alert('Error submitting assessment: ' + err);
@@ -529,7 +538,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
         showNotification({
           title: 'Error',
           message: 'Failed to delete draft',
-          color: 'red'
+          color: 'red',
         });
         return;
       }
@@ -554,7 +563,10 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
 
   // ========== SCORING / ADJUSTMENTS ==========
 
-  const calculatePerQuestionScores = (): { question: Question; score: number }[] => {
+  const calculatePerQuestionScores = (): {
+    question: Question;
+    score: number;
+  }[] => {
     if (!submission || !submission.answers) return [];
     return questions
       .map(question => {
@@ -579,7 +591,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       showNotification({
         title: 'Error',
         message: 'Failed to adjust submission score.',
-        color: 'red'
+        color: 'red',
       });
     }
   };
@@ -627,7 +639,8 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
         const hasTeamOptions =
           assessment.granularity === 'team' && teamOptions.length > 0;
         const hasMemberOptions =
-          assessment.granularity === 'individual' && teamMembersOptions.length > 0;
+          assessment.granularity === 'individual' &&
+          teamMembersOptions.length > 0;
 
         // If it's a "Team Member Selection" question, we want to wait until
         // we have the relevant teamOptions or teamMembersOptions
@@ -638,7 +651,9 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
 
         return (
           <Fragment key={question._id}>
-            {(hasTeamOptions || hasMemberOptions || question.type !== 'Team Member Selection') && (
+            {(hasTeamOptions ||
+              hasMemberOptions ||
+              question.type !== 'Team Member Selection') && (
               <TakeAssessmentCard
                 index={index}
                 question={question}
@@ -676,7 +691,9 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
               Delete Draft
             </Button>
           )}
-          <Button variant="default" onClick={handleSaveDraft}>Save Draft</Button>
+          <Button variant="default" onClick={handleSaveDraft}>
+            Save Draft
+          </Button>
           <Button
             onClick={handleSubmitClick}
             loading={isSubmitting}
@@ -702,7 +719,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
           max={submission ? submission.score + 100 : undefined}
           required
         />
-        <Group justify='flex-end' mt="md">
+        <Group justify="flex-end" mt="md">
           <Button
             variant="default"
             onClick={() => setShowAdjustScoreModal(false)}
@@ -723,7 +740,9 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
       >
         <ScrollArea style={{ height: '60vh' }}>
           {calculatePerQuestionScores().map(({ question, score }, idx) => {
-            const ans = submission?.answers.find(a => a.question === question._id);
+            const ans = submission?.answers.find(
+              a => a.question === question._id
+            );
             const formatted = ans
               ? formatAnswer(extractAnswerValue(ans), question.type)
               : 'No answer provided';
@@ -739,7 +758,7 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
             );
           })}
         </ScrollArea>
-        <Group justify='flex-end' mt="md">
+        <Group justify="flex-end" mt="md">
           <Button onClick={() => setShowSummaryModal(false)}>Close</Button>
         </Group>
       </Modal>
@@ -762,16 +781,18 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
               {isScoredQuestion(question) && (
                 <Text>
                   Score:{' '}
-                  {submission?.answers.find(
-                    a => a.question === question._id
-                  )?.score || 0}
+                  {submission?.answers.find(a => a.question === question._id)
+                    ?.score || 0}
                 </Text>
               )}
             </div>
           ))}
         </ScrollArea>
-        <Group justify='flex-end' mt="md">
-          <Button variant="default" onClick={() => setShowConfirmationModal(false)}>
+        <Group justify="flex-end" mt="md">
+          <Button
+            variant="default"
+            onClick={() => setShowConfirmationModal(false)}
+          >
             Cancel
           </Button>
           <Button onClick={handleSubmit}>Confirm</Button>
@@ -801,8 +822,11 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
         onClose={() => setShowBackModal(false)}
         title="Leaving submission"
       >
-        <Text>Are you sure you want to leave this page? Any unsaved changes will be lost.</Text>
-        <Group justify='flex-end' mt="md">
+        <Text>
+          Are you sure you want to leave this page? Any unsaved changes will be
+          lost.
+        </Text>
+        <Group justify="flex-end" mt="md">
           <Button variant="default" onClick={() => setShowBackModal(false)}>
             Cancel
           </Button>
@@ -821,8 +845,11 @@ const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
           Are you sure you want to delete your draft submission? This action
           cannot be undone.
         </Text>
-        <Group justify='flex-end' mt="md">
-          <Button variant="default" onClick={() => setShowDeleteDraftModal(false)}>
+        <Group justify="flex-end" mt="md">
+          <Button
+            variant="default"
+            onClick={() => setShowDeleteDraftModal(false)}
+          >
             Cancel
           </Button>
           <Button color="red" onClick={confirmDeleteDraft}>

--- a/multi-git-dashboard/src/components/views/TakeAssessmentInline.tsx
+++ b/multi-git-dashboard/src/components/views/TakeAssessmentInline.tsx
@@ -1,0 +1,783 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* Example file: components/views/TakeAssessmentInline.tsx */
+
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  Fragment
+} from 'react';
+import {
+  Container,
+  Button,
+  Text,
+  Modal,
+  Group,
+  ScrollArea,
+  Divider,
+  NumberInput,
+} from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { InternalAssessment } from '@shared/types/InternalAssessment';
+import {
+  Question,
+  QuestionUnion,
+  MultipleChoiceQuestion,
+  MultipleResponseQuestion,
+  ScaleQuestion,
+  NumberQuestion,
+} from '@shared/types/Question';
+import {
+  AnswerUnion
+} from '@shared/types/Answer';
+import { AnswerInput } from '@shared/types/AnswerInput';
+import { Submission } from '@shared/types/Submission';
+import { User } from '@shared/types/User';
+import TakeAssessmentCard from '@/components/cards/TakeAssessmentCard';
+import { useRouter } from 'next/router';
+import { isTrial } from '@/lib/auth/utils';
+
+interface TakeAssessmentInlineProps {
+  courseId: string;
+  assessmentId: string;
+  onReturnToOverview: () => void;
+}
+
+const TakeAssessmentInline: React.FC<TakeAssessmentInlineProps> = ({
+  assessmentId,
+  onReturnToOverview,
+}) => {
+  const router = useRouter();
+  const [assessment, setAssessment] = useState<InternalAssessment | null>(null);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [answers, setAnswers] = useState<{ [questionId: string]: AnswerInput }>({});
+  const [submission, setSubmission] = useState<Submission | undefined>();
+
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [showConfirmationModal, setShowConfirmationModal] = useState<boolean>(false);
+  const [missingRequiredQuestions, setMissingRequiredQuestions] = useState<string[]>([]);
+  const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
+
+  const [showAdjustScoreModal, setShowAdjustScoreModal] = useState<boolean>(false);
+  const [newAdjustedScore, setNewAdjustedScore] = useState<number | undefined>(undefined);
+
+  const [showSummaryModal, setShowSummaryModal] = useState<boolean>(false);
+  const [showBackModal, setShowBackModal] = useState<boolean>(false);
+  const [showDeleteDraftModal, setShowDeleteDraftModal] = useState<boolean>(false);
+
+  const [teamOptions, setTeamOptions] = useState<
+    {
+      value: string;
+      label: string;
+      members: { value: string; label: string }[];
+    }[]
+  >([]);
+
+  const [teamMembersOptions, setTeamMembersOptions] = useState<
+    { value: string; label: string }[]
+  >([]);
+
+  const isTrialVar = isTrial();
+
+  const questionsApiRoute = `/api/internal-assessments/${assessmentId}/questions`;
+  const submitAssessmentApiRoute = `/api/internal-assessments/${assessmentId}/submit`;
+  const assessmentApiRoute = `/api/internal-assessments/${assessmentId}`;
+  const assignedEntitiesApiRoute = `/api/assignment-sets/${assessmentId}/assignment-sets/graderunmarked`;
+
+  // =========== UTILS =============
+  const isScoredQuestion = (
+    question: QuestionUnion
+  ): question is MultipleChoiceQuestion | MultipleResponseQuestion | ScaleQuestion | NumberQuestion => {
+    return (
+      (question.type === 'Multiple Choice' ||
+       question.type === 'Multiple Response' ||
+       question.type === 'Scale' ||
+       question.type === 'Number') &&
+      question.isScored
+    );
+  };
+
+  const extractAnswerValue = (answer: AnswerUnion): AnswerInput => {
+    switch (answer.type) {
+      case 'Team Member Selection Answer':
+        if (assessment?.granularity === 'team') {
+          const userIds = answer.selectedUserIds;
+          const teamIds = teamOptions
+            .filter(team =>
+              team.members.some(member => userIds.includes(member.value))
+            )
+            .map(team => team.value);
+          return teamIds;
+        } else {
+          return answer.selectedUserIds;
+        }
+      case 'Multiple Response Answer':
+        return answer.values;
+      case 'Multiple Choice Answer':
+      case 'Scale Answer':
+      case 'Short Response Answer':
+      case 'Long Response Answer':
+      case 'NUSNET ID Answer':
+      case 'NUSNET Email Answer':
+      case 'Number Answer':
+        return answer.value;
+      case 'Date Answer':
+        if (answer.startDate && answer.endDate) {
+          return [new Date(answer.startDate), new Date(answer.endDate)];
+        } else if (answer.value) {
+          return new Date(answer.value);
+        } else {
+          return undefined;
+        }
+      default:
+        return undefined;
+    }
+  };
+
+  const formatAnswerForSubmission = (
+    question: Question,
+    answer: AnswerInput
+  ): Partial<AnswerUnion> => {
+    switch (question.type) {
+      case 'Team Member Selection':
+        if (assessment?.granularity === 'team') {
+          const selectedTeamIds = answer as string[];
+          const memberIds = selectedTeamIds.flatMap(teamId => {
+            const team = teamOptions.find(t => t.value === teamId);
+            return team ? team.members.map(member => member.value) : [];
+          });
+          return { selectedUserIds: memberIds as string[] };
+        } else {
+          return { selectedUserIds: answer as string[] };
+        }
+      case 'Multiple Response':
+        return { values: answer as string[] };
+      case 'Scale':
+      case 'Number':
+        return { value: answer as number };
+      case 'Multiple Choice':
+      case 'Short Response':
+      case 'Long Response':
+      case 'NUSNET ID':
+      case 'NUSNET Email':
+        return { value: answer as string };
+      case 'Date':
+        if (Array.isArray(answer)) {
+          const [startDate, endDate] = answer as [Date | null, Date | null];
+          return {
+            startDate: startDate || undefined,
+            endDate: endDate || undefined,
+          };
+        } else {
+          return { value: (answer as Date) || undefined };
+        }
+      default:
+        return {};
+    }
+  };
+
+  const isAnswerEmpty = (answer: AnswerInput): boolean => {
+    if (answer === undefined || answer === null) {
+      return true;
+    }
+    if (typeof answer === 'string') {
+      return answer.trim() === '';
+    }
+    if (typeof answer === 'number') {
+      return false;
+    }
+    if (answer instanceof Date) {
+      return isNaN(answer.getTime());
+    }
+    if (Array.isArray(answer)) {
+      const arrayAnswer = answer as any[];
+      if (arrayAnswer.length === 0) {
+        return true;
+      }
+      if (arrayAnswer.every(item => typeof item === 'string')) {
+        return arrayAnswer.every(item => item.trim() === '');
+      }
+      if (arrayAnswer.every(item => item instanceof Date)) {
+        return arrayAnswer.every(item => isNaN(new Date(item).getTime()));
+      }
+      return false;
+    }
+    return false;
+  };
+
+  const formatAnswer = (answer: AnswerInput, questionType: string): string => {
+    if (answer === undefined || answer === null || answer === '') {
+      return 'No answer provided';
+    }
+    switch (questionType) {
+      case 'Multiple Response':
+        return Array.isArray(answer)
+          ? (answer as string[]).join(', ')
+          : answer.toString();
+      case 'Scale':
+        return (answer as number).toString();
+      case 'Multiple Choice':
+      case 'Short Response':
+      case 'Long Response':
+      case 'NUSNET ID':
+      case 'NUSNET Email':
+        return answer as string;
+      case 'Date':
+        if (Array.isArray(answer)) {
+          const [start, end] = answer as [Date | null, Date | null];
+          return `${start ? start.toLocaleDateString() : 'N/A'} - ${end ? end.toLocaleDateString() : 'N/A'}`;
+        } else {
+          return answer
+            ? (answer as Date).toLocaleDateString()
+            : 'No date selected';
+        }
+      case 'Number':
+        return (answer as number).toString();
+      case 'Team Member Selection':
+        if (Array.isArray(answer)) {
+          if (assessment?.granularity === 'team') {
+            const selectedTeams = answer as string[];
+            const selectedTeamDetails = selectedTeams.map(teamId => {
+              const team = teamOptions.find(option => option.value === teamId);
+              if (team) {
+                const memberNames = team.members
+                  .map(member => member.label)
+                  .join(', ');
+                return `${team.label}: ${memberNames}`;
+              } else {
+                return `Team ${teamId}`;
+              }
+            });
+            return selectedTeamDetails.join('; ');
+          } else if (assessment?.granularity === 'individual') {
+            const selectedMembers = answer as string[];
+            const selectedNames = selectedMembers
+              .map(
+                id =>
+                  teamMembersOptions.find(option => option.value === id)?.label || id
+              )
+              .join(', ');
+            return selectedNames;
+          } else {
+            return '';
+          }
+        } else {
+          return 'No selection made';
+        }
+      default:
+        return answer.toString();
+    }
+  };
+
+  // =========== DATA FETCH =============
+  const fetchAssessment = useCallback(async () => {
+    try {
+      if (assessment) return;
+
+      const resp = await fetch(assessmentApiRoute);
+      if (!resp.ok) {
+        throw new Error('Failed to fetch assessment');
+      }
+      const data: InternalAssessment = await resp.json();
+      setAssessment(data);
+    } catch (e) {
+      console.error(e);
+      showNotification({
+        title: 'Error',
+        message: 'Failed to load assessment data.',
+        color: 'red'
+      });
+    }
+  }, [assessment, assessmentApiRoute]);
+
+  const fetchQuestions = useCallback(async () => {
+    try {
+      const resp = await fetch(questionsApiRoute);
+      if (!resp.ok) {
+        throw new Error('Failed to fetch questions');
+      }
+      const data: Question[] = await resp.json();
+      setQuestions(data);
+    } catch (e) {
+      console.error(e);
+      showNotification({
+        title: 'Error',
+        message: 'Failed to load questions.',
+        color: 'red'
+      });
+    }
+  }, [questionsApiRoute]);
+
+  const fetchAssignedEntities = useCallback(async () => {
+    try {
+      if (!assessment) return;
+
+      const resp = await fetch(assignedEntitiesApiRoute);
+      if (!resp.ok) {
+        throw new Error('Failed to fetch assigned entities');
+      }
+      const data = await resp.json();
+
+      if (assessment.granularity === 'team') {
+        const teams = data as any[];
+        const options = teams.map(team => ({
+          value: team._id,
+          label: `Team ${team.number}`,
+          members: team.members.map((member: { _id: any; name: any; }) => ({
+            value: member._id,
+            label: member.name,
+          })),
+        }));
+        setTeamOptions(options);
+      } else if (assessment.granularity === 'individual') {
+        const users = data as User[];
+        const options = users.map(u => ({
+          value: u._id,
+          label: u.name,
+        }));
+        setTeamMembersOptions(options);
+      }
+    } catch (e) {
+      console.error(e);
+      showNotification({
+        title: 'Error',
+        message: 'Failed to load assigned data.',
+        color: 'red'
+      });
+    }
+  }, [assessment, assignedEntitiesApiRoute]);
+
+  // =========== LIFECYCLE =============
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const handleRouteChangeStart = (url: string) => {
+      onReturnToOverview();
+    };
+
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+    };
+  }, [router, onReturnToOverview]);
+
+  useEffect(() => {
+    fetchAssessment();
+  }, [fetchAssessment]);
+
+  useEffect(() => {
+    if (assessment) {
+      fetchQuestions();
+      fetchAssignedEntities();
+    }
+  }, [assessment, fetchQuestions, fetchAssignedEntities]);
+
+  // =========== EVENT HANDLERS =============
+  const handleAnswerChange = (questionId: string, answer: AnswerInput) => {
+    setAnswers(prev => ({
+      ...prev,
+      [questionId]: answer,
+    }));
+  };
+
+  const handleSubmitClick = () => {
+    const missingQuestions = questions
+      .map((q, i) => ({ q, i }))
+      .filter(({ q }) => q.isRequired && isAnswerEmpty(answers[q._id]))
+      .map(({ i }) => `Question ${i + 1}`);
+
+    if (missingQuestions.length > 0) {
+      setMissingRequiredQuestions(missingQuestions);
+      setShowErrorModal(true);
+    } else {
+      setShowConfirmationModal(true);
+    }
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    try {
+      const formattedAnswers = Object.entries(answers)
+        .map(([qId, ans]) => {
+          const questionObj = questions.find(q => q._id === qId);
+          if (!questionObj) return null;
+          return {
+            question: qId,
+            type: questionObj.type + ' Answer',
+            ...formatAnswerForSubmission(questionObj, ans),
+          };
+        })
+        .filter((a): a is AnswerUnion => a !== null);
+
+      const submissionData = {
+        answers: formattedAnswers,
+        isDraft: false,
+        submissionId: submission?._id,
+      };
+
+      const resp = await fetch(submitAssessmentApiRoute, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(submissionData),
+      });
+      if (!resp.ok) {
+        throw new Error('Error submitting assessment');
+      }
+
+      const { submission: savedSubmission } = await resp.json();
+      setSubmission(savedSubmission);
+
+      // If you want to discard the submission data after final submission:
+      // (Based on your note “submit clicked will delete saved answers after submission is complete”)
+      setSubmission(undefined);
+      setAnswers({});
+
+      showNotification({
+        title: 'Submission Successful',
+        message: 'Your assessment has been submitted.',
+        color: 'green',
+      });
+
+      // Return to overview
+      onReturnToOverview();
+    } catch (err) {
+      console.error(err);
+      alert('Error submitting assessment: ' + err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleBackClick = () => {
+    setShowBackModal(true);
+  };
+  const confirmBack = () => {
+    // Optionally discard unsaved data
+    setSubmission(undefined);
+    setAnswers({});
+    setShowBackModal(false);
+    onReturnToOverview();
+  };
+
+  const handleDeleteDraft = () => {
+    setShowDeleteDraftModal(true);
+  };
+  const confirmDeleteDraft = async () => {
+    if (!submission?._id) return;
+    try {
+      const resp = await fetch(`/api/submissions/${submission._id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!resp.ok) {
+        showNotification({
+          title: 'Error',
+          message: 'Failed to delete draft',
+          color: 'red'
+        });
+        return;
+      }
+      setSubmission(undefined);
+      setAnswers({});
+      setShowDeleteDraftModal(false);
+      showNotification({
+        title: 'Draft Deleted',
+        message: 'Your draft submission was deleted.',
+        color: 'red',
+      });
+      onReturnToOverview();
+    } catch (err) {
+      console.error(err);
+      showNotification({
+        title: 'Error',
+        message: 'Failed to delete draft submission.',
+        color: 'red',
+      });
+    }
+  };
+
+  // ========== SCORING / ADJUSTMENTS ==========
+
+  const calculatePerQuestionScores = (): { question: Question; score: number }[] => {
+    if (!submission || !submission.answers) return [];
+    return questions
+      .map(question => {
+        const ans = submission.answers.find(a => a.question === question._id);
+        return { question, score: ans?.score || 0 };
+      })
+      .filter(({ question }) => isScoredQuestion(question));
+  };
+
+  const adjustSubmissionScore = async (
+    submissionId: string,
+    adjustedScore: number
+  ) => {
+    try {
+      await fetch(`/api/submissions/${submissionId}/adjust-score`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ adjustedScore }),
+      });
+    } catch (err) {
+      console.error(err);
+      showNotification({
+        title: 'Error',
+        message: 'Failed to adjust submission score.',
+        color: 'red'
+      });
+    }
+  };
+
+  const handleAdjustScoreSubmit = async () => {
+    if (newAdjustedScore === undefined || !submission?._id) {
+      showNotification({
+        title: 'Error',
+        message: 'Please enter a valid score or no submission found.',
+        color: 'red',
+      });
+      return;
+    }
+
+    try {
+      await adjustSubmissionScore(submission._id, newAdjustedScore);
+      setShowAdjustScoreModal(false);
+      setNewAdjustedScore(undefined);
+
+      showNotification({
+        title: 'Score Adjusted',
+        message: 'The submission score has been successfully adjusted.',
+        color: 'green',
+      });
+    } catch (err: any) {
+      showNotification({
+        title: 'Error',
+        message: err?.message || 'Failed to adjust score.',
+        color: 'red',
+      });
+    }
+  };
+
+  // ========== RENDER ==========
+  if (!assessment) return null;
+
+  return (
+    <Container mb="xl">
+      <div>
+        <h1>{assessment.assessmentName}</h1>
+        <p>{assessment.description}</p>
+      </div>
+
+      {questions.map((question, index) => {
+        const hasTeamOptions =
+          assessment.granularity === 'team' && teamOptions.length > 0;
+        const hasMemberOptions =
+          assessment.granularity === 'individual' && teamMembersOptions.length > 0;
+
+        // If it's a "Team Member Selection" question, we want to wait until
+        // we have the relevant teamOptions or teamMembersOptions
+        const isDisabled =
+          question.type === 'Team Member Selection' &&
+          submission &&
+          !submission.isDraft;
+
+        return (
+          <Fragment key={question._id}>
+            {(hasTeamOptions || hasMemberOptions || question.type !== 'Team Member Selection') && (
+              <TakeAssessmentCard
+                index={index}
+                question={question}
+                answer={answers[question._id]}
+                onAnswerChange={ans => handleAnswerChange(question._id, ans)}
+                disabled={isDisabled}
+                teamMembersOptions={
+                  question.type === 'Team Member Selection' &&
+                  assessment.granularity === 'individual'
+                    ? teamMembersOptions
+                    : undefined
+                }
+                teamOptions={
+                  question.type === 'Team Member Selection' &&
+                  assessment.granularity === 'team'
+                    ? teamOptions
+                    : undefined
+                }
+                assessmentGranularity={assessment.granularity}
+                isFaculty={false}
+                submission={submission}
+              />
+            )}
+          </Fragment>
+        );
+      })}
+
+      <Group mt="md" justify="space-between">
+        <Button variant="default" onClick={handleBackClick}>
+          Back
+        </Button>
+        <Group>
+          {submission && submission.isDraft && (
+            <Button variant="default" color="red" onClick={handleDeleteDraft}>
+              Delete Draft
+            </Button>
+          )}
+          {/* Temporarily disabled
+              <Button variant="default" onClick={handleSaveDraft}>Save Draft</Button>
+          */}
+          <Button
+            onClick={handleSubmitClick}
+            loading={isSubmitting}
+            disabled={isTrialVar}
+            variant={submission && submission.isDraft ? 'filled' : 'outline'}
+          >
+            Submit
+          </Button>
+        </Group>
+      </Group>
+
+      <Modal
+        opened={showAdjustScoreModal}
+        onClose={() => setShowAdjustScoreModal(false)}
+        title="Adjust Submission Score"
+      >
+        <NumberInput
+          label="New Score"
+          placeholder="Enter the adjusted score"
+          value={newAdjustedScore}
+          onChange={value => setNewAdjustedScore(value as number | undefined)}
+          min={0}
+          max={submission ? submission.score + 100 : undefined}
+          required
+        />
+        <Group justify='flex-end' mt="md">
+          <Button
+            variant="default"
+            onClick={() => setShowAdjustScoreModal(false)}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleAdjustScoreSubmit} color="green">
+            Submit
+          </Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={showSummaryModal}
+        onClose={() => setShowSummaryModal(false)}
+        title="Score Summary"
+        size="lg"
+      >
+        <ScrollArea style={{ height: '60vh' }}>
+          {calculatePerQuestionScores().map(({ question, score }, idx) => {
+            const ans = submission?.answers.find(a => a.question === question._id);
+            const formatted = ans
+              ? formatAnswer(extractAnswerValue(ans), question.type)
+              : 'No answer provided';
+            return (
+              <div key={question._id} style={{ marginBottom: '1rem' }}>
+                <Text>
+                  {idx + 1}. {question.text}
+                </Text>
+                <Text>Answer: {formatted}</Text>
+                <Text>Score: {score}</Text>
+                <Divider my="sm" />
+              </div>
+            );
+          })}
+        </ScrollArea>
+        <Group justify='flex-end' mt="md">
+          <Button onClick={() => setShowSummaryModal(false)}>Close</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={showConfirmationModal}
+        onClose={() => setShowConfirmationModal(false)}
+        title="Confirm Submission"
+        size="lg"
+      >
+        <ScrollArea style={{ height: '60vh' }}>
+          {questions.map((question, index) => (
+            <div key={question._id} style={{ marginBottom: '1rem' }}>
+              <Text>
+                {index + 1}. {question.text}
+              </Text>
+              <Text>
+                Answer: {formatAnswer(answers[question._id], question.type)}
+              </Text>
+              {isScoredQuestion(question) && (
+                <Text>
+                  Score:{' '}
+                  {submission?.answers.find(
+                    a => a.question === question._id
+                  )?.score || 0}
+                </Text>
+              )}
+            </div>
+          ))}
+        </ScrollArea>
+        <Group justify='flex-end' mt="md">
+          <Button variant="default" onClick={() => setShowConfirmationModal(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit}>Confirm</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={showErrorModal}
+        onClose={() => setShowErrorModal(false)}
+        title="Missing Required Questions"
+      >
+        <Text>
+          Please answer the following required questions before submitting:
+        </Text>
+        <ul>
+          {missingRequiredQuestions.map(qnum => (
+            <li key={qnum}>{qnum}</li>
+          ))}
+        </ul>
+        <Button onClick={() => setShowErrorModal(false)} mt="md">
+          OK
+        </Button>
+      </Modal>
+
+      <Modal
+        opened={showBackModal}
+        onClose={() => setShowBackModal(false)}
+        title="Leaving submission"
+      >
+        <Text>Are you sure you want to leave this page? Any unsaved changes will be lost.</Text>
+        <Group justify='flex-end' mt="md">
+          <Button variant="default" onClick={() => setShowBackModal(false)}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={confirmBack}>
+            Leave Page
+          </Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={showDeleteDraftModal}
+        onClose={() => setShowDeleteDraftModal(false)}
+        title="Delete Draft Submission"
+      >
+        <Text>
+          Are you sure you want to delete your draft submission? This action
+          cannot be undone.
+        </Text>
+        <Group justify='flex-end' mt="md">
+          <Button variant="default" onClick={() => setShowDeleteDraftModal(false)}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={confirmDeleteDraft}>
+            Delete Draft
+          </Button>
+        </Group>
+      </Modal>
+    </Container>
+  );
+};
+
+export default TakeAssessmentInline;

--- a/multi-git-dashboard/src/lib/auth/utils.ts
+++ b/multi-git-dashboard/src/lib/auth/utils.ts
@@ -35,6 +35,18 @@ export const hasCoursePermission = (
 export const hasCourseFacultyPermission = (courseId: string) =>
   hasCoursePermission(courseId, CourseRoles.Faculty);
 
+
+export const isTrialUser = (...CrispRoles: CrispRole[]) => {
+  const { data: session } = useSession();
+  return (
+    (session?.user.crispRole && CrispRoles.includes(session.user.crispRole)) ||
+    false
+  );
+};
+
+export const isTrial = () =>
+  isTrialUser(CrispRoles.TrialUser);
+
 export const logLogin = async () => {
   const res = await fetch('/api/metrics/login', {
     method: 'POST',

--- a/multi-git-dashboard/src/lib/auth/utils.ts
+++ b/multi-git-dashboard/src/lib/auth/utils.ts
@@ -35,7 +35,6 @@ export const hasCoursePermission = (
 export const hasCourseFacultyPermission = (courseId: string) =>
   hasCoursePermission(courseId, CourseRoles.Faculty);
 
-
 export const isTrialUser = (...CrispRoles: CrispRole[]) => {
   const { data: session } = useSession();
   return (
@@ -44,8 +43,7 @@ export const isTrialUser = (...CrispRoles: CrispRole[]) => {
   );
 };
 
-export const isTrial = () =>
-  isTrialUser(CrispRoles.TrialUser);
+export const isTrial = () => isTrialUser(CrispRoles.TrialUser);
 
 export const logLogin = async () => {
   const res = await fetch('/api/metrics/login', {

--- a/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId].tsx
@@ -401,7 +401,9 @@ const InternalAssessmentDetail: React.FC = () => {
                   userIdToNameMap={userIdToNameMap}
                   teachingStaff={teachingTeam}
                   initialAssignedTeams={
-                    assessment.granularity === 'team' ? assignedTeams : undefined
+                    assessment.granularity === 'team'
+                      ? assignedTeams
+                      : undefined
                   }
                   initialAssignedUsers={
                     assessment.granularity === 'individual'

--- a/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId].tsx
@@ -14,6 +14,7 @@ import {
 } from '@shared/types/AssessmentAssignmentSet';
 import { Team } from '@shared/types/Team';
 import { AssessmentResult } from '@shared/types/AssessmentResults';
+import TakeAssessmentInline from '@/components/views/TakeAssessmentInline';
 
 const InternalAssessmentDetail: React.FC = () => {
   const router = useRouter();
@@ -25,6 +26,7 @@ const InternalAssessmentDetail: React.FC = () => {
   const questionsApiRoute = `/api/internal-assessments/${assessmentId}/questions`;
   const teachingTeamApiRoute = `/api/courses/${id}/teachingteam`;
 
+  const [showTakeAssessment, setShowTakeAssessment] = useState(false);
   const [userIdToNameMap, setUserIdToNameMap] = useState<{
     [key: string]: string;
   }>({});
@@ -350,88 +352,97 @@ const InternalAssessmentDetail: React.FC = () => {
 
   return (
     <Container>
-      <Tabs value={activeTab}>
-        <Tabs.List>
-          <Tabs.Tab
-            value="Overview"
-            onClick={() => setActiveTabAndSave('Overview')}
-          >
-            Overview
-          </Tabs.Tab>
-
-          {permission && (
+      {showTakeAssessment ? (
+        <TakeAssessmentInline
+          courseId={id}
+          assessmentId={assessmentId}
+          onReturnToOverview={() => setShowTakeAssessment(false)}
+        />
+      ) : (
+        <Tabs value={activeTab}>
+          <Tabs.List>
             <Tabs.Tab
-              value="Questions"
-              onClick={() => setActiveTabAndSave('Questions')}
+              value="Overview"
+              onClick={() => setActiveTabAndSave('Overview')}
             >
-              Questions
+              Overview
             </Tabs.Tab>
-          )}
 
-          {permission && (
-            <Tabs.Tab
-              value="Internal Results"
-              onClick={() => setActiveTabAndSave('Internal Results')}
-            >
-              Results
-            </Tabs.Tab>
-          )}
-        </Tabs.List>
-
-        <Tabs.Panel value="Overview">
-          {id &&
-            assessment &&
-            ((assignedTeams && assignedTeams.length > 0) ||
-              (assignedUsers && assignedUsers.length > 0)) && (
-              <AssessmentInternalOverview
-                courseId={id}
-                assessment={assessment}
-                hasFacultyPermission={permission}
-                onUpdateAssessment={fetchAssessment}
-                questions={questions}
-                userIdToNameMap={userIdToNameMap}
-                teachingStaff={teachingTeam}
-                initialAssignedTeams={
-                  assessment.granularity === 'team' ? assignedTeams : undefined
-                }
-                initialAssignedUsers={
-                  assessment.granularity === 'individual'
-                    ? assignedUsers
-                    : undefined
-                }
-              />
+            {permission && (
+              <Tabs.Tab
+                value="Questions"
+                onClick={() => setActiveTabAndSave('Questions')}
+              >
+                Questions
+              </Tabs.Tab>
             )}
-        </Tabs.Panel>
 
-        {permission && (
-          <Tabs.Panel value="Questions">
-            <AssessmentInternalForm
-              assessment={assessment}
-              questions={questions}
-              addQuestion={addQuestion}
-              handleSaveQuestion={handleSaveQuestion}
-              handleDeleteQuestion={handleDeleteQuestion}
-              onAssessmentUpdated={fetchAssessment}
-            />
+            {permission && (
+              <Tabs.Tab
+                value="Internal Results"
+                onClick={() => setActiveTabAndSave('Internal Results')}
+              >
+                Results
+              </Tabs.Tab>
+            )}
+          </Tabs.List>
+
+          <Tabs.Panel value="Overview">
+            {id &&
+              assessment &&
+              ((assignedTeams && assignedTeams.length > 0) ||
+                (assignedUsers && assignedUsers.length > 0)) && (
+                <AssessmentInternalOverview
+                  courseId={id}
+                  assessment={assessment}
+                  hasFacultyPermission={permission}
+                  onUpdateAssessment={fetchAssessment}
+                  questions={questions}
+                  userIdToNameMap={userIdToNameMap}
+                  teachingStaff={teachingTeam}
+                  initialAssignedTeams={
+                    assessment.granularity === 'team' ? assignedTeams : undefined
+                  }
+                  initialAssignedUsers={
+                    assessment.granularity === 'individual'
+                      ? assignedUsers
+                      : undefined
+                  }
+                  onTakeAssessmentClicked={() => setShowTakeAssessment(true)}
+                />
+              )}
           </Tabs.Panel>
-        )}
 
-        {permission &&
-          assessmentResults &&
-          assessmentResults.length > 0 &&
-          assessment && (
-            <Tabs.Panel value="Internal Results">
-              <AssessmentInternalResults
-                teachingTeam={teachingTeam}
-                results={assessmentResults}
-                assignedTeams={assignedTeams}
-                assignedUsers={assignedUsers}
-                maxScore={assessment.maxMarks}
-                assessmentReleaseNumber={assessment.releaseNumber}
+          {permission && (
+            <Tabs.Panel value="Questions">
+              <AssessmentInternalForm
+                assessment={assessment}
+                questions={questions}
+                addQuestion={addQuestion}
+                handleSaveQuestion={handleSaveQuestion}
+                handleDeleteQuestion={handleDeleteQuestion}
+                onAssessmentUpdated={fetchAssessment}
               />
             </Tabs.Panel>
           )}
-      </Tabs>
+
+          {permission &&
+            assessmentResults &&
+            assessmentResults.length > 0 &&
+            assessment && (
+              <Tabs.Panel value="Internal Results">
+                <AssessmentInternalResults
+                  teachingTeam={teachingTeam}
+                  results={assessmentResults}
+                  assignedTeams={assignedTeams}
+                  assignedUsers={assignedUsers}
+                  maxScore={assessment.maxMarks}
+                  assessmentReleaseNumber={assessment.releaseNumber}
+                />
+              </Tabs.Panel>
+            )}
+        </Tabs>
+      )}
     </Container>
   );
 };

--- a/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId]/submission/[submissionId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId]/submission/[submissionId].tsx
@@ -1,12 +1,10 @@
-// pages/courses/[id]/internal-assessments/[assessmentId]/submission/[submissionId].tsx
-
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { Submission } from '@shared/types/Submission';
 import { showNotification } from '@mantine/notifications';
 import { InternalAssessment } from '@shared/types/InternalAssessment';
-import TakeAssessment from '../take';
 import { hasFacultyPermission } from '@/lib/auth/utils';
+import EditAssessment from '@/components/views/EditAssessment';
 
 const ViewSubmissionPage: React.FC = () => {
   const router = useRouter();
@@ -63,7 +61,7 @@ const ViewSubmissionPage: React.FC = () => {
   return (
     <>
       {submission && (
-        <TakeAssessment
+        <EditAssessment
           inputAssessment={assessment}
           existingSubmission={submission}
           canEdit={canEdit}


### PR DESCRIPTION
## Description

To be honest, I couldn't fix the routing issue for that page, so I completely removed the problematic /take page and just made it an alternate view of the /:assessmentId page. I couldn't fix the routing issue for that page.

Also, I re-enabled submission drafts. They were disabled before because of various issues with having multiple submissions created and stuff, but I've since added a lot of anti-duplicate checks so it should now work fine. Needs testing on dev before deploying to prod.