### PR TITLE
Remove mongoose transactions

### DIFF
--- a/backend/services/peerReviewAssessmentService.ts
+++ b/backend/services/peerReviewAssessmentService.ts
@@ -6,7 +6,7 @@ import {
   BadRequestError,
   MissingAuthorizationError,
 } from './errors';
-import mongoose, { Types } from 'mongoose';
+import { Types } from 'mongoose';
 import TeamSetModel from '@models/TeamSet';
 import { createAssignmentSet } from './assessmentAssignmentSetService';
 import AssessmentResultModel from '@models/AssessmentResult';
@@ -75,8 +75,6 @@ export const createPeerReviewAssessmentForCourse = async (
   courseId: string,
   peerReviewAssessmentData: PeerReviewAssessmentData
 ) => {
-  const session = await mongoose.startSession();
-  session.startTransaction();
   const {
     assessmentName,
     description,
@@ -97,92 +95,81 @@ export const createPeerReviewAssessmentForCourse = async (
     ? new Date(gradingEndDate)
     : null;
 
+  const course = await CourseModel.findById(courseId).populate('students');
+  if (!course) throw new NotFoundError('Course not found');
+
+  const teamSet = await TeamSetModel.findById(teamSetId);
+  if (!teamSet) throw new NotFoundError('TeamSet not found');
+
+  // 1. Create InternalAssessment (peer_review type)
+  const assessment = await new InternalAssessmentModel({
+    course: courseId,
+    assessmentName: assessmentName,
+    assessmentType: 'peer_review',
+    description: description,
+    startDate: startDate,
+    endDate: internalAssessmentEndDate,
+    maxMarks: maxMarks,
+    scaleToMaxMarks: scaleToMaxMarks,
+    granularity: reviewerType.toLowerCase(),
+    teamSet: teamSet._id,
+    areSubmissionsEditable: false,
+    results: [],
+    isReleased: false,
+    questions: [], // no questions for peer review
+    questionsTotalMarks: 0,
+    releaseNumber: 0,
+  }).save();
+
+  // 2) Create AssessmentResults for all students
+  const results = await Promise.all(
+    (course.students as any[]).map(student =>
+      new AssessmentResultModel({
+        assessment: assessment._id,
+        student,
+        marks: [],
+        averageScore: 0,
+      }).save()
+    )
+  );
+
+  assessment.results = results.map(r => r._id);
+  await assessment.save();
+
+  course.internalAssessments.push(assessment._id);
+  await course.save();
+
+  // 3. Create PeerReview linked to InternalAssessment
+  const createPeerReviewData: PeerReviewSettings = {
+    assessmentName: assessmentName,
+    description: description,
+    startDate: startDate,
+    endDate: endDate,
+    teamSetId: teamSetId,
+    reviewerType: reviewerType,
+    taAssignments: taAssignments,
+    minReviews: minReviews,
+    maxReviews: maxReviews,
+    gradingStartDate: gradingStartDate,
+    gradingEndDate: gradingEndDate,
+    internalAssessmentId: assessment._id.toString(),
+  };
+  const newPeerReview = await createPeerReviewById(
+    courseId,
+    createPeerReviewData,
+    null
+  );
+
   try {
-    const course = await CourseModel.findById(courseId)
-      .populate('students')
-      .session(session);
-    if (!course) throw new NotFoundError('Course not found');
-
-    const teamSet = await TeamSetModel.findById(teamSetId).session(session);
-    if (!teamSet) throw new NotFoundError('TeamSet not found');
-
-    // 1. Create InternalAssessment (peer_review type)
-    const assessment = await new InternalAssessmentModel({
-      course: courseId,
-      assessmentName: assessmentName,
-      assessmentType: 'peer_review',
-      description: description,
-      startDate: startDate,
-      endDate: internalAssessmentEndDate,
-      maxMarks: maxMarks,
-      scaleToMaxMarks: scaleToMaxMarks,
-      granularity: reviewerType.toLowerCase(),
-      teamSet: teamSet._id,
-      areSubmissionsEditable: false,
-      results: [],
-      isReleased: false,
-      questions: [], // no questions for peer review
-      questionsTotalMarks: 0,
-      releaseNumber: 0,
-    }).save({ session });
-
-    // 2) Create AssessmentResults for all students
-    const results = await Promise.all(
-      (course.students as any[]).map(student =>
-        new AssessmentResultModel({
-          assessment: assessment._id,
-          student,
-          marks: [],
-          averageScore: 0,
-        }).save({ session })
-      )
+    await createAssignmentSet(
+      assessment._id.toString(),
+      teamSet._id.toString()
     );
-
-    assessment.results = results.map(r => r._id);
-    await assessment.save({ session });
-
-    course.internalAssessments.push(assessment._id);
-    await course.save({ session });
-
-    // 3. Create PeerReview linked to InternalAssessment
-    const createPeerReviewData: PeerReviewSettings = {
-      assessmentName: assessmentName,
-      description: description,
-      startDate: startDate,
-      endDate: endDate,
-      teamSetId: teamSetId,
-      reviewerType: reviewerType,
-      taAssignments: taAssignments,
-      minReviews: minReviews,
-      maxReviews: maxReviews,
-      gradingStartDate: gradingStartDate,
-      gradingEndDate: gradingEndDate,
-      internalAssessmentId: assessment._id.toString(),
-    };
-    const newPeerReview = await createPeerReviewById(
-      courseId,
-      createPeerReviewData,
-      session
-    );
-
-    await session.commitTransaction();
-    session.endSession();
-
-    try {
-      await createAssignmentSet(
-        assessment._id.toString(),
-        teamSet._id.toString()
-      );
-    } catch (e) {
-      console.error('createAssignmentSet failed:', e);
-    }
-
-    return newPeerReview;
   } catch (e) {
-    await session.abortTransaction();
-    session.endSession();
-    throw e;
+    console.error('createAssignmentSet failed:', e);
   }
+
+  return newPeerReview;
 };
 
 export const updatePeerReviewAssessmentById = async (

--- a/backend/services/peerReviewService.ts
+++ b/backend/services/peerReviewService.ts
@@ -1,7 +1,7 @@
 import PeerReviewModel from '@models/PeerReview';
 import CourseModel from '@models/Course';
 import { BadRequestError, NotFoundError } from './errors';
-import mongoose, { ClientSession, startSession, Types } from 'mongoose';
+import { ClientSession, Types } from 'mongoose';
 import PeerReviewAssignmentModel from '@models/PeerReviewAssignment';
 import PeerReviewCommentModel from '@models/PeerReviewComment';
 import PeerReviewSubmissionModel, {
@@ -332,7 +332,7 @@ export interface PeerReviewSettings {
 export const createPeerReviewById = async (
   courseId: string,
   peerReviewData: PeerReviewSettings,
-  session: ClientSession
+  session: ClientSession | null = null
 ) => {
   const course = await CourseModel.findById(courseId);
   if (!course) {
@@ -385,49 +385,37 @@ export const createPeerReviewById = async (
 };
 
 export const deletePeerReviewById = async (peerReviewId: string) => {
-  const session = await mongoose.startSession();
-  session.startTransaction();
-  try {
-    const peerReview = await PeerReviewModel.findById(peerReviewId);
-    if (!peerReview) throw new NotFoundError('Peer review not found');
+  const peerReview = await PeerReviewModel.findById(peerReviewId);
+  if (!peerReview) throw new NotFoundError('Peer review not found');
 
-    const prAssignments: PeerReviewAssignment[] =
-      await PeerReviewAssignmentModel.find({
-        peerReviewId,
-      });
-    const assignmentIds = prAssignments.map(assignment => assignment._id);
-
-    // Delete associated comments
-    const delCommentsRes = await PeerReviewCommentModel.deleteMany({
-      peerReviewAssignmentId: { $in: assignmentIds },
+  const prAssignments: PeerReviewAssignment[] =
+    await PeerReviewAssignmentModel.find({
+      peerReviewId,
     });
+  const assignmentIds = prAssignments.map(assignment => assignment._id);
 
-    // Delete peer review assignments
-    const delAssignmentsRes =
-      await deleteAssignmentsByPeerReviewId(peerReviewId);
+  // Delete associated comments
+  const delCommentsRes = await PeerReviewCommentModel.deleteMany({
+    peerReviewAssignmentId: { $in: assignmentIds },
+  });
 
-    const delPeerReviewRes =
-      await PeerReviewModel.findByIdAndDelete(peerReviewId);
-    if (!delPeerReviewRes)
-      throw new NotFoundError('Peer review not found for deletion');
+  // Delete peer review assignments
+  const delAssignmentsRes = await deleteAssignmentsByPeerReviewId(peerReviewId);
 
-    await session.commitTransaction();
-    session.endSession();
+  const delPeerReviewRes =
+    await PeerReviewModel.findByIdAndDelete(peerReviewId);
+  if (!delPeerReviewRes)
+    throw new NotFoundError('Peer review not found for deletion');
 
-    return {
-      deletedPeerReviewId: peerReviewId,
-      deletedPeerReviewTitle: peerReview.title,
-      deleted: {
-        comments: delCommentsRes.deletedCount || 0,
-        assignments: delAssignmentsRes.deletedCount || 0,
-        peerReview: delPeerReviewRes ? 1 : 0,
-      },
-    };
-  } catch (error) {
-    await session.abortTransaction();
-    session.endSession();
-    throw error;
-  }
+  return {
+    deletedPeerReviewId: peerReviewId,
+    deletedPeerReviewTitle: peerReview.title,
+    deleted: {
+      comments: delCommentsRes.deletedCount || 0,
+      assignments: delAssignmentsRes.deletedCount || 0,
+      peerReview: delPeerReviewRes ? 1 : 0,
+    },
+  };
 };
 
 export const updatePeerReviewById = async (

--- a/backend/test/services/peerReviewAssessmentService.test.ts
+++ b/backend/test/services/peerReviewAssessmentService.test.ts
@@ -200,14 +200,6 @@ beforeEach(async () => {
   await UserModel.deleteMany({});
 
   (getPeerReviewCommentsBySubmissionId as jest.Mock).mockResolvedValue([]);
-
-  jest.spyOn(mongoose, 'startSession').mockImplementation(async () => {
-    const session = await mongoose.connection.startSession();
-    jest.spyOn(session, 'startTransaction').mockImplementation(() => undefined as any);
-    jest.spyOn(session, 'commitTransaction').mockImplementation(async () => undefined as any);
-    jest.spyOn(session, 'abortTransaction').mockImplementation(async () => undefined as any);
-    return session;
-  });
 });
 
 afterAll(async () => {

--- a/backend/test/services/peerReviewService.test.ts
+++ b/backend/test/services/peerReviewService.test.ts
@@ -244,14 +244,6 @@ beforeEach(async () => {
   (deleteAssignmentsByPeerReviewId as jest.Mock).mockResolvedValue({
     deletedCount: 0,
   });
-
-  // mock startSession to avoid transaction requirement
-  jest.spyOn(mongoose, 'startSession').mockResolvedValue({
-    startTransaction: jest.fn(),
-    commitTransaction: jest.fn(),
-    abortTransaction: jest.fn(),
-    endSession: jest.fn(),
-  } as any);
 });
 
 afterAll(async () => {
@@ -788,30 +780,22 @@ describe('peerReviewService', () => {
       delSpy.mockRestore();
     });
 
-    it('throws NotFound when peer review missing and aborts transaction', async () => {
-      const session = await mongoose.startSession();
-      const abortSpy = jest.spyOn(session as any, 'abortTransaction');
-
+    it('throws NotFound when peer review missing', async () => {
       await expect(deletePeerReviewById(oidStr())).rejects.toBeInstanceOf(
         NotFoundError
       );
-      expect(abortSpy).toHaveBeenCalled();
     });
 
-    it('throws NotFound when deletion returns null (covers branch) and aborts', async () => {
+    it('throws NotFound when deletion returns null (covers branch)', async () => {
       const pr = await makePeerReview();
 
       const spy = jest
         .spyOn(PeerReviewModel, 'findByIdAndDelete')
         .mockResolvedValueOnce(null as any);
 
-      const session = await mongoose.startSession();
-      const abortSpy = jest.spyOn(session as any, 'abortTransaction');
-
       await expect(
         deletePeerReviewById(pr._id.toString())
       ).rejects.toBeInstanceOf(NotFoundError);
-      expect(abortSpy).toHaveBeenCalled();
 
       spy.mockRestore();
     });


### PR DESCRIPTION
## Description

Transactions are not supported. This PR is to remove them to support peer reviews.

## Changes

- Updated peerReviewAssessment and peerReview services to remove transactions.

Resolves #475