### PR TITLE
Fix Grading UI, Flagging, and Add Submission Filter

### DIFF
--- a/backend/services/peerReviewCommentsService.ts
+++ b/backend/services/peerReviewCommentsService.ts
@@ -423,10 +423,18 @@ export const flagPeerReviewCommentById = async (
 
   const reviewee = await fetchReviewee(assignment.reviewee.toString());
   const isSupervisingTA = reviewee.TA?.toString() === userId;
+  const hasGradingTask = await PeerReviewGradingTaskModel.exists({
+    peerReviewId: comment.peerReviewId,
+    peerReviewSubmissionId: comment.peerReviewSubmissionId,
+    grader: oid(userId),
+  });
+  const isAssignedGrader = Boolean(hasGradingTask);
 
-  // Course coordinator can flag any comment and if TA, can only flag comments of teams they are supervising
+  // Course coordinator can flag any comment.
+  // TA can flag if supervising this reviewee team OR if assigned as grader for this submission.
   if (
-    (userCourseRole === COURSE_ROLE.TA && isSupervisingTA) ||
+    (userCourseRole === COURSE_ROLE.TA &&
+      (isSupervisingTA || isAssignedGrader)) ||
     userCourseRole === COURSE_ROLE.Faculty
   ) {
     if (flagStatus) {
@@ -436,9 +444,7 @@ export const flagPeerReviewCommentById = async (
       comment.flaggedAt = new Date();
       comment.flaggedBy = oid(userId);
       comment.unflagReason = '';
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (comment as any).unflaggedAt = null;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (comment as any).unflaggedBy = null;
     } else {
       // Unflagging: clear flag state and record unflag details

--- a/backend/services/peerReviewCommentsService.ts
+++ b/backend/services/peerReviewCommentsService.ts
@@ -412,52 +412,25 @@ export const flagPeerReviewCommentById = async (
   const comment = await PeerReviewCommentModel.findById(commentId);
   if (!comment) throw new NotFoundError(COMMENT_NOT_FOUND);
 
-  const assignment = await PeerReviewAssignmentModel.findById(
-    comment.peerReviewAssignmentId
-  );
-  if (!assignment) {
-    throw new NotFoundError(
-      'Peer review assignment not found for this comment'
-    );
+  // TA/Faculty moderation is allowed at any point (draft/submitted, grading in-progress/completed).
+  if (flagStatus) {
+    // Flagging: record flag details and clear any prior unflag state
+    comment.isFlagged = true;
+    comment.flagReason = flagReason ?? '';
+    comment.flaggedAt = new Date();
+    comment.flaggedBy = oid(userId);
+    comment.unflagReason = '';
+    (comment as any).unflaggedAt = null;
+    (comment as any).unflaggedBy = null;
+  } else {
+    // Unflagging: clear flag state and record unflag details
+    comment.isFlagged = false;
+    comment.unflagReason = flagReason ?? '';
+    comment.unflaggedAt = new Date();
+    comment.unflaggedBy = oid(userId);
   }
-
-  const reviewee = await fetchReviewee(assignment.reviewee.toString());
-  const isSupervisingTA = reviewee.TA?.toString() === userId;
-  const hasGradingTask = await PeerReviewGradingTaskModel.exists({
-    peerReviewId: comment.peerReviewId,
-    peerReviewSubmissionId: comment.peerReviewSubmissionId,
-    grader: oid(userId),
-  });
-  const isAssignedGrader = Boolean(hasGradingTask);
-
-  // Course coordinator can flag any comment.
-  // TA can flag if supervising this reviewee team OR if assigned as grader for this submission.
-  if (
-    (userCourseRole === COURSE_ROLE.TA &&
-      (isSupervisingTA || isAssignedGrader)) ||
-    userCourseRole === COURSE_ROLE.Faculty
-  ) {
-    if (flagStatus) {
-      // Flagging: record flag details and clear any prior unflag state
-      comment.isFlagged = true;
-      comment.flagReason = flagReason ?? '';
-      comment.flaggedAt = new Date();
-      comment.flaggedBy = oid(userId);
-      comment.unflagReason = '';
-      (comment as any).unflaggedAt = null;
-      (comment as any).unflaggedBy = null;
-    } else {
-      // Unflagging: clear flag state and record unflag details
-      comment.isFlagged = false;
-      comment.unflagReason = flagReason ?? '';
-      comment.unflaggedAt = new Date();
-      comment.unflaggedBy = oid(userId);
-    }
-    await comment.save();
-    return;
-  }
-
-  throw new MissingAuthorizationError(UNAUTHORIZED_TO_FLAG_COMMENTS);
+  await comment.save();
+  return;
 };
 
 // Helpers
@@ -569,7 +542,10 @@ const decorateCommentsForViewer = async (
       : null;
 
     let displayAuthorName = c.author?.name;
-    let canManage = canModerateAll;
+    let canManage =
+      canModerateAll ||
+      userCourseRole === COURSE_ROLE.TA ||
+      userCourseRole === COURSE_ROLE.Faculty;
 
     // Only show team name if there's no individual author (system-generated comments)
     if (

--- a/backend/services/peerReviewGradingTaskService.ts
+++ b/backend/services/peerReviewGradingTaskService.ts
@@ -32,6 +32,22 @@ const assertPeerReviewActive = async (peerReviewId: Types.ObjectId) => {
   }
 };
 
+const assertSubmissionSubmittedForTask = async (
+  peerReviewSubmissionId: Types.ObjectId
+) => {
+  const submission = await PeerReviewSubmissionModel.findById(
+    peerReviewSubmissionId
+  )
+    .select('status')
+    .lean();
+
+  if (!submission) throw new NotFoundError('Peer review submission not found');
+
+  if (submission.status !== 'Submitted') {
+    throw new BadRequestError('Cannot grade unsubmitted reviews');
+  }
+};
+
 const resolvePeerReviewAndSubmission = async (
   assessmentId: string,
   peerReviewSubmissionId: string
@@ -140,6 +156,9 @@ export const updateGradingTaskById = async (
   const task = await PeerReviewGradingTaskModel.findById(taskId);
   if (!task) throw new NotFoundError(TASK_NOT_FOUND);
   await assertPeerReviewActive(task.peerReviewId as Types.ObjectId);
+  await assertSubmissionSubmittedForTask(
+    task.peerReviewSubmissionId as Types.ObjectId
+  );
 
   // Only the grader can modify their task
   if (String(task.grader) !== String(oid(userId))) {
@@ -173,6 +192,9 @@ export const submitGradingTaskById = async (userId: string, taskId: string) => {
   const task = await PeerReviewGradingTaskModel.findById(taskId);
   if (!task) throw new NotFoundError(TASK_NOT_FOUND);
   await assertPeerReviewActive(task.peerReviewId as Types.ObjectId);
+  await assertSubmissionSubmittedForTask(
+    task.peerReviewSubmissionId as Types.ObjectId
+  );
 
   if (String(task.grader) !== String(oid(userId))) {
     throw new MissingAuthorizationError(ACCESS_DENIED);

--- a/backend/test/services/peerReviewCommentsService.test.ts
+++ b/backend/test/services/peerReviewCommentsService.test.ts
@@ -1128,7 +1128,7 @@ describe('peerReviewCommentsService', () => {
       ).rejects.toBeInstanceOf(NotFoundError);
     });
 
-    it('throws NotFound when assignment missing for comment', async () => {
+    it('Faculty can flag even if assignment is missing for comment', async () => {
       const pr = await makePeerReview();
       (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
 
@@ -1148,7 +1148,11 @@ describe('peerReviewCommentsService', () => {
           true,
           'r'
         )
-      ).rejects.toBeInstanceOf(NotFoundError);
+      ).resolves.toBeUndefined();
+
+      const updated = await PeerReviewCommentModel.findById(comment._id);
+      expect(updated?.isFlagged).toBe(true);
+      expect(updated?.flagReason).toBe('r');
     });
 
     it('TA supervising can flag comment', async () => {
@@ -1243,7 +1247,7 @@ describe('peerReviewCommentsService', () => {
       ).rejects.toBeInstanceOf(MissingAuthorizationError);
     });
 
-    it('TA not supervising cannot flag comment', async () => {
+    it('TA not supervising can still flag comment', async () => {
       const taId = oid();
       const pr = await makePeerReview();
       (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
@@ -1258,9 +1262,13 @@ describe('peerReviewCommentsService', () => {
           COURSE_ROLE.TA,
           comment._id.toString(),
           true,
-          'not allowed'
+          'allowed now'
         )
-      ).rejects.toBeInstanceOf(MissingAuthorizationError);
+      ).resolves.toBeUndefined();
+
+      const updated = await PeerReviewCommentModel.findById(comment._id);
+      expect(updated?.isFlagged).toBe(true);
+      expect(updated?.flagReason).toBe('allowed now');
     });
   });
 });

--- a/backend/test/services/peerReviewGradingTaskService.test.ts
+++ b/backend/test/services/peerReviewGradingTaskService.test.ts
@@ -721,4 +721,60 @@ describe('peerReviewGradingTaskService', () => {
       bulkAssignGradersByAssessmentId(courseUnset._id.toString(), assessmentUnset._id.toString(), 1, true)
     ).rejects.toBeInstanceOf(BadRequestError);
   });
+
+  it('blocks grading updates/submission when linked review submission is not submitted or missing', async () => {
+    const grader = await makeUser('grader-status-guard');
+    const course = await makeCourse();
+    const ts = await makeTeamSet(course._id);
+    const assessment = await makeAssessment(course._id, ts._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, {
+      status: 'Active',
+    });
+    const reviewee = await makeTeam(ts._id);
+    const assignment = await makeAssignment(pr._id, reviewee._id);
+
+    // Draft submission should fail grading updates and submission
+    const draftSubmission = await makeSubmission(pr._id, assignment._id, {
+      status: 'Draft',
+    });
+    const draftTask = await new PeerReviewGradingTaskModel({
+      peerReviewId: pr._id,
+      peerReviewSubmissionId: draftSubmission._id,
+      grader: grader._id,
+      status: 'Assigned',
+    }).save();
+
+    await expect(
+      updateGradingTaskById(grader._id.toString(), draftTask._id.toString(), {
+        score: 2,
+      })
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    await expect(
+      submitGradingTaskById(grader._id.toString(), draftTask._id.toString())
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    // Missing submission should fail after peer review active check passes
+    const missingSubmissionTask = await new PeerReviewGradingTaskModel({
+      peerReviewId: pr._id,
+      peerReviewSubmissionId: oid(),
+      grader: grader._id,
+      status: 'Assigned',
+    }).save();
+
+    await expect(
+      updateGradingTaskById(
+        grader._id.toString(),
+        missingSubmissionTask._id.toString(),
+        { score: 3 }
+      )
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    await expect(
+      submitGradingTaskById(
+        grader._id.toString(),
+        missingSubmissionTask._id.toString()
+      )
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
 });

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
@@ -303,33 +303,40 @@ const PeerReviewAccordionItem = forwardRef<
             <Stack>
               {currentTeam.repoUrl && (
                 <Stack w={250}>
-                  <Button
-                    component="a"
-                    href={currentTeam.repoUrl}
-                    rel="noreferrer"
-                    size="xs"
-                    target="_blank"
-                    variant="light"
-                    color="gray"
-                  >
-                    Go to Team's Github Repository
-                  </Button>
-                  <Button
-                    component="a"
-                    onClick={() =>
-                      router.push(
-                        `${router.asPath.replace(/\/$/, '')}/${assignmentOfTeam?.assignment._id}`
-                      )
-                    }
-                    size="xs"
-                    rel="noreferrer"
-                    target="_blank"
-                    variant="light"
-                    color="gray"
-                    disabled={numberOfReviewers === 0}
-                  >
-                    See Peer Review for Team
-                  </Button>
+                  {(() => {
+                    const assignmentId = assignmentOfTeam?.assignment._id;
+                    const canViewPeerReview = Boolean(assignmentId);
+
+                    return (
+                      <>
+                        <Button
+                          component="a"
+                          href={currentTeam.repoUrl}
+                          rel="noreferrer"
+                          size="xs"
+                          target="_blank"
+                          variant="light"
+                          color="gray"
+                        >
+                          Go to Team's Github Repository
+                        </Button>
+                        <Button
+                          onClick={() => {
+                            if (!canViewPeerReview || !assignmentId) return;
+                            router.push(
+                              `${router.asPath.replace(/\/$/, '')}/${assignmentId}`
+                            );
+                          }}
+                          size="xs"
+                          variant="light"
+                          color="gray"
+                          disabled={!canViewPeerReview}
+                        >
+                          See Peer Review for Team
+                        </Button>
+                      </>
+                    );
+                  })()}
                 </Stack>
               )}
               {isFaculty && (

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
@@ -21,6 +21,8 @@ import DeleteConfirmationModal from '../cards/Modals/DeleteConfirmationModal';
 import PeerReviewAssignments from './PeerReviewAssignments';
 import AddManualAssignmentBox from './AddManualAssignmentBox';
 
+type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+
 interface PeerReviewAccordionItemProps {
   currentTeam: PeerReviewTeamDTO;
   currentUserId?: string;
@@ -36,6 +38,7 @@ interface PeerReviewAccordionItemProps {
   assignmentOfTeam: RevieweeAssignmentsDTO | null;
   reviewerType: 'Individual' | 'Team';
   maxReviewsPerReviewer: number;
+  statusFilter?: SubmissionStatusFilter;
   showUnassignedOnly?: boolean;
   isFaculty: boolean;
   isTA: boolean;
@@ -63,6 +66,7 @@ const PeerReviewAccordionItem = forwardRef<
     assignmentOfTeam,
     reviewerType,
     maxReviewsPerReviewer,
+    statusFilter = 'All',
     showUnassignedOnly,
     isFaculty,
     isTA,
@@ -228,6 +232,7 @@ const PeerReviewAccordionItem = forwardRef<
                   >
                     <PeerReviewAssignments
                       assignments={currentTeam.assignedReviewsToTeam}
+                      statusFilter={statusFilter}
                       isFaculty={isFaculty}
                       isTA={isTA}
                       currentUserId={currentUserId}
@@ -276,6 +281,7 @@ const PeerReviewAccordionItem = forwardRef<
                             <>
                               <PeerReviewAssignments
                                 assignments={m.assignedReviews}
+                                statusFilter={statusFilter}
                                 isFaculty={isFaculty}
                                 isTA={isTA}
                                 currentUserId={currentUserId}
@@ -338,8 +344,7 @@ const PeerReviewAccordionItem = forwardRef<
                       style={{
                         maxHeight: 'calc(10 * 32px + 18px)',
                         height: 'auto',
-                        border: 'solid 1px',
-                        borderColor: '#505050',
+                        border: '0.5px solid gray',
                         borderRadius: '6px',
                         padding: '8px 0',
                         transition: 'max-height 0.2s',

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
@@ -21,7 +21,7 @@ import DeleteConfirmationModal from '../cards/Modals/DeleteConfirmationModal';
 import PeerReviewAssignments from './PeerReviewAssignments';
 import AddManualAssignmentBox from './AddManualAssignmentBox';
 
-type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+type SubmissionStatusValue = 'NotStarted' | 'Draft' | 'Submitted';
 
 interface PeerReviewAccordionItemProps {
   currentTeam: PeerReviewTeamDTO;
@@ -38,7 +38,7 @@ interface PeerReviewAccordionItemProps {
   assignmentOfTeam: RevieweeAssignmentsDTO | null;
   reviewerType: 'Individual' | 'Team';
   maxReviewsPerReviewer: number;
-  statusFilter?: SubmissionStatusFilter;
+  statusFilters?: SubmissionStatusValue[];
   showUnassignedOnly?: boolean;
   isFaculty: boolean;
   isTA: boolean;
@@ -66,7 +66,7 @@ const PeerReviewAccordionItem = forwardRef<
     assignmentOfTeam,
     reviewerType,
     maxReviewsPerReviewer,
-    statusFilter = 'All',
+    statusFilters = [],
     showUnassignedOnly,
     isFaculty,
     isTA,
@@ -232,7 +232,7 @@ const PeerReviewAccordionItem = forwardRef<
                   >
                     <PeerReviewAssignments
                       assignments={currentTeam.assignedReviewsToTeam}
-                      statusFilter={statusFilter}
+                      statusFilters={statusFilters}
                       isFaculty={isFaculty}
                       isTA={isTA}
                       currentUserId={currentUserId}
@@ -281,7 +281,7 @@ const PeerReviewAccordionItem = forwardRef<
                             <>
                               <PeerReviewAssignments
                                 assignments={m.assignedReviews}
-                                statusFilter={statusFilter}
+                                statusFilters={statusFilters}
                                 isFaculty={isFaculty}
                                 isTA={isTA}
                                 currentUserId={currentUserId}

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
@@ -4,11 +4,11 @@ import { useRouter } from 'next/router';
 import { AssignedReviewDTO } from '@shared/types/PeerReview';
 import { Team } from '@shared/types/Team';
 
-type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+type SubmissionStatusValue = 'NotStarted' | 'Draft' | 'Submitted';
 
 interface PeerReviewAssignmentsProps {
   assignments: AssignedReviewDTO[];
-  statusFilter?: SubmissionStatusFilter;
+  statusFilters?: SubmissionStatusValue[];
   isFaculty: boolean;
   isTA?: boolean;
   currentUserId?: string;
@@ -18,7 +18,7 @@ interface PeerReviewAssignmentsProps {
 
 const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
   assignments,
-  statusFilter = 'All',
+  statusFilters = [],
   isFaculty,
   isTA = false,
   currentUserId,
@@ -28,7 +28,7 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
   const router = useRouter();
 
   const filteredAssignments = assignments.filter(a =>
-    statusFilter === 'All' ? true : a.status === statusFilter
+    statusFilters.length === 0 ? true : statusFilters.includes(a.status)
   );
 
   if (filteredAssignments.length === 0) {

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
@@ -4,8 +4,11 @@ import { useRouter } from 'next/router';
 import { AssignedReviewDTO } from '@shared/types/PeerReview';
 import { Team } from '@shared/types/Team';
 
+type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+
 interface PeerReviewAssignmentsProps {
   assignments: AssignedReviewDTO[];
+  statusFilter?: SubmissionStatusFilter;
   isFaculty: boolean;
   isTA?: boolean;
   currentUserId?: string;
@@ -15,6 +18,7 @@ interface PeerReviewAssignmentsProps {
 
 const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
   assignments,
+  statusFilter = 'All',
   isFaculty,
   isTA = false,
   currentUserId,
@@ -23,7 +27,11 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
 }) => {
   const router = useRouter();
 
-  if (assignments.length === 0) {
+  const filteredAssignments = assignments.filter(a =>
+    statusFilter === 'All' ? true : a.status === statusFilter
+  );
+
+  if (filteredAssignments.length === 0) {
     return (
       <Text c="dimmed" size="xs" mb="xs">
         (no assignments found)
@@ -33,7 +41,7 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
 
   return (
     <Stack gap="sm" my="xs">
-      {assignments.map(a => {
+      {filteredAssignments.map(a => {
         const teamNumber =
           (a.assignment.reviewee as Partial<Team> | undefined)?.number ??
           (a.assignment.reviewee as { teamNumber?: number } | undefined)
@@ -100,6 +108,17 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
                 h="21.5px"
               >
                 Draft
+              </Badge>
+            )}
+            {a.status === 'NotStarted' && (
+              <Badge
+                color="gray"
+                variant="light"
+                size="sm"
+                radius="sm"
+                h="21.5px"
+              >
+                Not Started
               </Badge>
             )}
             {isFaculty && (

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewFileTree.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewFileTree.tsx
@@ -16,7 +16,7 @@ const PeerReviewFileTree: React.FC<PeerReviewFileTreeProps> = ({
   openFile,
   level = 0,
 }) => {
-  const [openDirs, setOpenDirs] = useState<{ [path: string]: boolean }>({});
+  const [isOpen, setIsOpen] = useState(level === 0);
 
   if (repoNode.type === 'file') {
     return (
@@ -30,7 +30,6 @@ const PeerReviewFileTree: React.FC<PeerReviewFileTreeProps> = ({
     );
   }
 
-  const isOpen = openDirs[repoNode.path] ?? false;
   return (
     <>
       <NavLink
@@ -42,9 +41,7 @@ const PeerReviewFileTree: React.FC<PeerReviewFileTreeProps> = ({
             <IconFolder size={16} style={{ marginLeft: '10px' }} />
           )
         }
-        onClick={() =>
-          setOpenDirs(prev => ({ ...prev, [repoNode.path]: !isOpen }))
-        }
+        onClick={() => setIsOpen(prev => !prev)}
         style={{ paddingLeft: `${level * 16}px` }}
       />
       {isOpen &&

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewTAAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewTAAccordianItem.tsx
@@ -17,6 +17,8 @@ import DeleteConfirmationModal from '../cards/Modals/DeleteConfirmationModal';
 import PeerReviewAssignments from './PeerReviewAssignments';
 import { useDisclosure } from '@mantine/hooks';
 
+type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+
 interface PeerReviewTAAccordionItemProps {
   teams: {
     value: string;
@@ -27,6 +29,7 @@ interface PeerReviewTAAccordionItemProps {
     label: string;
   }[];
   TAToAssignments: TAToAssignmentsMap;
+  statusFilter?: SubmissionStatusFilter;
   showUnassignedOnly?: boolean;
   isFaculty: boolean;
   addManualAssignment: (
@@ -48,6 +51,7 @@ const PeerReviewTAAccordionItem = forwardRef<
   ({
     teams,
     TAToAssignments,
+    statusFilter = 'All',
     showUnassignedOnly,
     isFaculty,
     addManualAssignment,
@@ -69,11 +73,19 @@ const PeerReviewTAAccordionItem = forwardRef<
         [string, { taName: string; assignedReviews: AssignedReviewDTO[] }]
       >;
 
+      const matchesStatus = (a: AssignedReviewDTO) =>
+        statusFilter === 'All' ? true : a.status === statusFilter;
+
       return temp.filter(([taId, info]) => {
-        if (!showUnassignedOnly) return true;
-        return taId && info.assignedReviews.length === 0;
+        if (!showUnassignedOnly) {
+          if (statusFilter === 'All') return true;
+          return info.assignedReviews.some(matchesStatus);
+        }
+
+        const visibleAssignments = info.assignedReviews.filter(matchesStatus);
+        return taId && visibleAssignments.length === 0;
       });
-    }, [TAToAssignments, showUnassignedOnly]);
+    }, [TAToAssignments, showUnassignedOnly, statusFilter]);
 
     if (taEntries.length === 0 && showUnassignedOnly) return null; // Don't render the TA section if filtering for unassigned and there are none
 
@@ -133,6 +145,7 @@ const PeerReviewTAAccordionItem = forwardRef<
                       </Group>
                       <PeerReviewAssignments
                         assignments={info.assignedReviews}
+                        statusFilter={statusFilter}
                         isFaculty={isFaculty}
                         onDelete={(reviewee: Team) => {
                           setToBeDeletedReviewer({

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewTAAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewTAAccordianItem.tsx
@@ -17,7 +17,7 @@ import DeleteConfirmationModal from '../cards/Modals/DeleteConfirmationModal';
 import PeerReviewAssignments from './PeerReviewAssignments';
 import { useDisclosure } from '@mantine/hooks';
 
-type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+type SubmissionStatusValue = 'NotStarted' | 'Draft' | 'Submitted';
 
 interface PeerReviewTAAccordionItemProps {
   teams: {
@@ -29,7 +29,7 @@ interface PeerReviewTAAccordionItemProps {
     label: string;
   }[];
   TAToAssignments: TAToAssignmentsMap;
-  statusFilter?: SubmissionStatusFilter;
+  statusFilters?: SubmissionStatusValue[];
   showUnassignedOnly?: boolean;
   isFaculty: boolean;
   addManualAssignment: (
@@ -51,7 +51,7 @@ const PeerReviewTAAccordionItem = forwardRef<
   ({
     teams,
     TAToAssignments,
-    statusFilter = 'All',
+    statusFilters = [],
     showUnassignedOnly,
     isFaculty,
     addManualAssignment,
@@ -74,18 +74,18 @@ const PeerReviewTAAccordionItem = forwardRef<
       >;
 
       const matchesStatus = (a: AssignedReviewDTO) =>
-        statusFilter === 'All' ? true : a.status === statusFilter;
+        statusFilters.length === 0 ? true : statusFilters.includes(a.status);
 
       return temp.filter(([taId, info]) => {
         if (!showUnassignedOnly) {
-          if (statusFilter === 'All') return true;
+          if (statusFilters.length === 0) return true;
           return info.assignedReviews.some(matchesStatus);
         }
 
         const visibleAssignments = info.assignedReviews.filter(matchesStatus);
         return taId && visibleAssignments.length === 0;
       });
-    }, [TAToAssignments, showUnassignedOnly, statusFilter]);
+    }, [TAToAssignments, showUnassignedOnly, statusFilters]);
 
     if (taEntries.length === 0 && showUnassignedOnly) return null; // Don't render the TA section if filtering for unassigned and there are none
 
@@ -145,7 +145,7 @@ const PeerReviewTAAccordionItem = forwardRef<
                       </Group>
                       <PeerReviewAssignments
                         assignments={info.assignedReviews}
-                        statusFilter={statusFilter}
+                        statusFilters={statusFilters}
                         isFaculty={isFaculty}
                         onDelete={(reviewee: Team) => {
                           setToBeDeletedReviewer({

--- a/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
@@ -13,7 +13,7 @@ import {
   Badge,
   Divider,
   Popover,
-  Select,
+  Checkbox,
   Switch,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
@@ -46,7 +46,7 @@ enum NotificationType {
   Warning = 'Warning',
 }
 
-type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
+type SubmissionStatusValue = 'NotStarted' | 'Draft' | 'Submitted';
 
 const statusColor = (status: string) => {
   if (status === 'Closed') return 'red';
@@ -124,8 +124,9 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
     useDisclosure(false);
 
   const [showUnassignedOnly, setShowUnassignedOnly] = useState(false);
-  const [statusFilter, setStatusFilter] =
-    useState<SubmissionStatusFilter>('All');
+  const [statusFilters, setStatusFilters] = useState<SubmissionStatusValue[]>(
+    []
+  );
   const [filtersOpen, setFiltersOpen] = useState(false);
 
   const teamSetName =
@@ -182,9 +183,9 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
   }, [isTA, me?.userId, peerReviewInfo?.TAAssignments]);
 
   const hasStatusMatch = useCallback(
-    (statuses: Array<'NotStarted' | 'Draft' | 'Submitted'>) =>
-      statusFilter === 'All' || statuses.includes(statusFilter),
-    [statusFilter]
+    (status: SubmissionStatusValue) =>
+      statusFilters.length === 0 || statusFilters.includes(status),
+    [statusFilters]
   );
 
   const isUpcoming = peerReview.status === 'Upcoming';
@@ -432,7 +433,7 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                     <Popover.Target>
                       <Button
                         variant={
-                          statusFilter !== 'All' || showUnassignedOnly
+                          statusFilters.length > 0 || showUnassignedOnly
                             ? 'filled'
                             : 'light'
                         }
@@ -444,21 +445,19 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                     </Popover.Target>
                     <Popover.Dropdown>
                       <Stack gap="md" w={220}>
-                        <Select
+                        <Checkbox.Group
                           label="Submission Status"
-                          data={[
-                            { value: 'All', label: 'All' },
-                            { value: 'NotStarted', label: 'Not Started' },
-                            { value: 'Draft', label: 'Draft' },
-                            { value: 'Submitted', label: 'Submitted' },
-                          ]}
-                          value={statusFilter}
+                          value={statusFilters}
                           onChange={v =>
-                            setStatusFilter(
-                              (v as SubmissionStatusFilter) || 'All'
-                            )
+                            setStatusFilters(v as SubmissionStatusValue[])
                           }
-                        />
+                        >
+                          <Stack gap={6} mt="xs">
+                            <Checkbox value="NotStarted" label="Not Started" />
+                            <Checkbox value="Draft" label="Draft" />
+                            <Checkbox value="Submitted" label="Submitted" />
+                          </Stack>
+                        </Checkbox.Group>
 
                         {isFaculty && (
                           <Switch
@@ -475,7 +474,7 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                             size="xs"
                             variant="default"
                             onClick={() => {
-                              setStatusFilter('All');
+                              setStatusFilters([]);
                               setShowUnassignedOnly(false);
                             }}
                           >
@@ -538,7 +537,7 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                   label: `Team ${t.teamNumber}`,
                 }))}
                 TAToAssignments={peerReviewInfo.TAAssignments}
-                statusFilter={statusFilter}
+                statusFilters={statusFilters}
                 showUnassignedOnly={showUnassignedOnly}
                 isFaculty={isFaculty}
                 addManualAssignment={addManualAssignment}
@@ -553,14 +552,14 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                   peerReviewInfo.reviewerType === 'Individual'
                     ? team.members.some(member =>
                         member.assignedReviews.some(ar =>
-                          hasStatusMatch([ar.status])
+                          hasStatusMatch(ar.status)
                         )
                       )
                     : team.assignedReviewsToTeam.some(ar =>
-                        hasStatusMatch([ar.status])
+                        hasStatusMatch(ar.status)
                       );
 
-                if (!matchesStatusForTeam && statusFilter !== 'All')
+                if (!matchesStatusForTeam && statusFilters.length > 0)
                   return false;
 
                 if (!showUnassignedOnly) return true;
@@ -598,7 +597,7 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                     peerReviewInfo.assignmentsOfTeam[team.teamId]
                   }
                   maxReviewsPerReviewer={peerReview.maxReviewsPerReviewer}
-                  statusFilter={statusFilter}
+                  statusFilters={statusFilters}
                   showUnassignedOnly={showUnassignedOnly}
                   isFaculty={isFaculty}
                   isTA={isTA}

--- a/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
@@ -12,11 +12,14 @@ import {
   Stack,
   Badge,
   Divider,
+  Popover,
+  Select,
+  Switch,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useDisclosure } from '@mantine/hooks';
 import { Status } from '@shared/types/util/Status';
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import PeerReviewAccordionItem from '../peer-review/PeerReviewAccordianItem';
 import PeerReviewTAAccordianItem from '../peer-review/PeerReviewTAAccordianItem';
 import PeerReviewProgressOverview from '../peer-review/PeerReviewProgressOverview';
@@ -24,7 +27,6 @@ import { TeamSet } from '@shared/types/TeamSet';
 import { PeerReview, PeerReviewInfoDTO } from '@shared/types/PeerReview';
 import PeerReviewAssignmentForm from '../forms/PeerReviewAssignmentForm';
 import StartPeerReviewModal from '../cards/Modals/StartPeerReviewModal';
-import ShowUnassignedButton from '../peer-review/ShowUnassignedButton';
 import { useRouter } from 'next/router';
 import { formatDate } from '../../lib/utils';
 import { getMe, hasTAPermission } from '@/lib/auth/utils';
@@ -43,6 +45,8 @@ enum NotificationType {
   Info = 'Info',
   Warning = 'Warning',
 }
+
+type SubmissionStatusFilter = 'All' | 'NotStarted' | 'Draft' | 'Submitted';
 
 const statusColor = (status: string) => {
   if (status === 'Closed') return 'red';
@@ -120,6 +124,9 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
     useDisclosure(false);
 
   const [showUnassignedOnly, setShowUnassignedOnly] = useState(false);
+  const [statusFilter, setStatusFilter] =
+    useState<SubmissionStatusFilter>('All');
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const teamSetName =
     teamSets.find(ts => ts._id === peerReview.teamSetId)?.name ||
@@ -173,6 +180,18 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
     if (!mine?.assignedReviews) return [] as string[];
     return mine.assignedReviews.map(a => a.assignment._id);
   }, [isTA, me?.userId, peerReviewInfo?.TAAssignments]);
+
+  const hasStatusMatch = useCallback(
+    (statuses: Array<'NotStarted' | 'Draft' | 'Submitted'>) =>
+      statusFilter === 'All' || statuses.includes(statusFilter),
+    [statusFilter]
+  );
+
+  const isUpcoming = peerReview.status === 'Upcoming';
+  const isClosed = peerReview.status === 'Closed';
+  const isTAOnly = isTA && !isFaculty;
+  const showTAActionButton = isTAOnly && !isUpcoming;
+  const showTAFilterButton = isTAOnly && !isUpcoming && !isClosed;
 
   // Handlers
   const addManualAssignment = async (
@@ -319,46 +338,47 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
         </Notification>
       )}
       <Card withBorder radius="md" p="lg" my="md">
-        <Group justify="space-between" align="flex-start" mb="xs">
-          <Stack gap={2}>
+        <Group mb="xs">
+          <Stack gap={6}>
             <Text fw={800} fz="xl">
               {peerReview.title}
             </Text>
-            <Text c="dimmed" fz="sm">
+            <Text c="dimmed" fz="sm" mb="xs">
               {peerReview.description || '—'}
             </Text>
+            <Group gap="xs" mt={2}>
+              <Badge color={statusColor(peerReview.status)}>
+                Review Period: {peerReview.status}
+              </Badge>
+              {isFaculty &&
+                (peerReview.taAssignments ? (
+                  <Badge variant="light" color="teal">
+                    TA Reviews Enabled
+                  </Badge>
+                ) : (
+                  <Badge variant="light" color="red">
+                    TA Reviews Disabled
+                  </Badge>
+                ))}
+              <Badge variant="light">
+                Reviewer Type: {peerReview.reviewerType}
+              </Badge>
+            </Group>
           </Stack>
-
-          <Group gap="xs" mt={6}>
-            <Badge color={statusColor(peerReview.status)}>
-              Review Period: {peerReview.status}
-            </Badge>
-            {isFaculty &&
-              (peerReview.taAssignments ? (
-                <Badge variant="light" color="teal">
-                  TA Reviews Enabled
-                </Badge>
-              ) : (
-                <Badge variant="light" color="red">
-                  TA Reviews Disabled
-                </Badge>
-              ))}
-            <Badge variant="light">
-              Reviewer Type: {peerReview.reviewerType}
-            </Badge>
-          </Group>
         </Group>
 
         <Divider my="sm" />
 
-        <Group justify="space-between" align="flex-end" mt="sm">
-          <Group gap="xl">
-            <Stack gap={2}>
-              <Text fz="xs" c="dimmed">
-                Team Set
-              </Text>
-              <Text fz="sm">{teamSetName}</Text>
-            </Stack>
+        <Stack gap="md" mt="sm">
+          <Group gap="xl" wrap="wrap">
+            {isFaculty && (
+              <Stack gap={2}>
+                <Text fz="xs" c="dimmed">
+                  Team Set
+                </Text>
+                <Text fz="sm">{teamSetName}</Text>
+              </Stack>
+            )}
 
             <Stack gap={2}>
               <Text fz="xs" c="dimmed">
@@ -378,40 +398,105 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
             </Stack>
           </Group>
 
-          {isFaculty && (
-            <Group gap="sm" mt="md">
-              {peerReview.status === 'Upcoming' && (
-                <Button color="green" onClick={openStartModal}>
-                  Start Peer Review Now
+          <Group justify="space-between" align="center" wrap="wrap">
+            {isFaculty ? (
+              <Group gap="sm">
+                {peerReview.status === 'Upcoming' && (
+                  <Button color="green" onClick={openStartModal}>
+                    Start Peer Review Now
+                  </Button>
+                )}
+
+                <Button
+                  color="yellow"
+                  variant="light"
+                  onClick={openAssignmentForm}
+                  disabled={peerReview.status === 'Closed'}
+                >
+                  Assign Peer Reviews
                 </Button>
-              )}
+              </Group>
+            ) : (
+              <div />
+            )}
 
-              <Button
-                color="yellow"
-                variant="light"
-                onClick={openAssignmentForm}
-                disabled={peerReview.status === 'Closed'}
-              >
-                Assign Peer Reviews
-              </Button>
+            {(isFaculty || showTAActionButton) && (
+              <Group gap="sm" ml="auto">
+                {(isFaculty || showTAFilterButton) && (
+                  <Popover
+                    opened={filtersOpen}
+                    onChange={setFiltersOpen}
+                    position="bottom-end"
+                    withArrow
+                  >
+                    <Popover.Target>
+                      <Button
+                        variant={
+                          statusFilter !== 'All' || showUnassignedOnly
+                            ? 'filled'
+                            : 'light'
+                        }
+                        color="gray"
+                        onClick={() => setFiltersOpen(o => !o)}
+                      >
+                        Filter
+                      </Button>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                      <Stack gap="md" w={220}>
+                        <Select
+                          label="Submission Status"
+                          data={[
+                            { value: 'All', label: 'All' },
+                            { value: 'NotStarted', label: 'Not Started' },
+                            { value: 'Draft', label: 'Draft' },
+                            { value: 'Submitted', label: 'Submitted' },
+                          ]}
+                          value={statusFilter}
+                          onChange={v =>
+                            setStatusFilter(
+                              (v as SubmissionStatusFilter) || 'All'
+                            )
+                          }
+                        />
 
-              <ShowUnassignedButton
-                peerReviewId={peerReview._id}
-                courseId={courseId}
-                onFilterChange={setShowUnassignedOnly}
-              />
-            </Group>
-          )}
-          {(isFaculty || isTA) && (
-            <Button
-              variant="light"
-              color="blue"
-              onClick={goToAssessmentManagement}
-            >
-              {isFaculty ? 'Manage Assessment' : 'Grade Reviews'}
-            </Button>
-          )}
-        </Group>
+                        {isFaculty && (
+                          <Switch
+                            label="Show Unassigned Only"
+                            checked={showUnassignedOnly}
+                            onChange={e =>
+                              setShowUnassignedOnly(e.currentTarget.checked)
+                            }
+                          />
+                        )}
+
+                        <Group justify="space-between" mt={4}>
+                          <Button
+                            size="xs"
+                            variant="default"
+                            onClick={() => {
+                              setStatusFilter('All');
+                              setShowUnassignedOnly(false);
+                            }}
+                          >
+                            Reset
+                          </Button>
+                        </Group>
+                      </Stack>
+                    </Popover.Dropdown>
+                  </Popover>
+                )}
+                <Button
+                  variant="light"
+                  color="blue"
+                  onClick={goToAssessmentManagement}
+                >
+                  {isFaculty ? 'Manage Assessment' : 'Grade Reviews'}
+                </Button>
+              </Group>
+            )}
+          </Group>
+        </Stack>
       </Card>
 
       {peerReviewInfo && !peerReviewInfo.teams ? (
@@ -453,17 +538,31 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                   label: `Team ${t.teamNumber}`,
                 }))}
                 TAToAssignments={peerReviewInfo.TAAssignments}
+                statusFilter={statusFilter}
                 showUnassignedOnly={showUnassignedOnly}
                 isFaculty={isFaculty}
                 addManualAssignment={addManualAssignment}
                 deleteManualAssignment={deleteManualAssignment}
               />
             )}
-
             <Divider my="lg" />
 
             {peerReviewInfo.teams
               .filter(team => {
+                const matchesStatusForTeam =
+                  peerReviewInfo.reviewerType === 'Individual'
+                    ? team.members.some(member =>
+                        member.assignedReviews.some(ar =>
+                          hasStatusMatch([ar.status])
+                        )
+                      )
+                    : team.assignedReviewsToTeam.some(ar =>
+                        hasStatusMatch([ar.status])
+                      );
+
+                if (!matchesStatusForTeam && statusFilter !== 'All')
+                  return false;
+
                 if (!showUnassignedOnly) return true;
 
                 // When filtering for unassigned, only show teams with unassigned reviewers
@@ -499,6 +598,7 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
                     peerReviewInfo.assignmentsOfTeam[team.teamId]
                   }
                   maxReviewsPerReviewer={peerReview.maxReviewsPerReviewer}
+                  statusFilter={statusFilter}
                   showUnassignedOnly={showUnassignedOnly}
                   isFaculty={isFaculty}
                   isTA={isTA}

--- a/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId]/peer-review/[submissionId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/internal-assessments/[assessmentId]/peer-review/[submissionId].tsx
@@ -280,6 +280,7 @@ const PeerReviewGradingDetailPage: React.FC = () => {
     isPeerReviewActive && isFaculty && !myTask && isSubmitted;
   const canGrade =
     isPeerReviewActive &&
+    isSubmitted &&
     !!myTask &&
     (myTask.status === 'Assigned' || myTask.status === 'InProgress');
   const gradingTasks = dto?.gradingTasks ?? [];
@@ -492,7 +493,7 @@ const PeerReviewGradingDetailPage: React.FC = () => {
               h="27px"
               onClick={() => setGradeOpen(true)}
             >
-              Submit Grade
+              Grade Review
             </Button>
           )}
         </Group>

--- a/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
@@ -521,13 +521,9 @@ const PeerReviewDetail: React.FC = () => {
   ]);
 
   // Flag comment handler
-  const requestFlagComment = useCallback(
-    async (commentId: string) => {
-      if (!canEdit) return;
-      setFlagCommentId(commentId);
-    },
-    [canEdit]
-  );
+  const requestFlagComment = useCallback(async (commentId: string) => {
+    setFlagCommentId(commentId);
+  }, []);
 
   const handleFlagComment = useCallback(
     async (flagReason: string) => {

--- a/multi-git-dashboard/src/styles/PeerReview.module.css
+++ b/multi-git-dashboard/src/styles/PeerReview.module.css
@@ -41,7 +41,7 @@
   flex-direction: column;
   align-items: stretch;
   height: 100%;
-  border: 1px solid #505050;
+  border: 0.5px solid gray;
   border-radius: 6px;
   padding-left: 8px;
   padding-right: 8px;
@@ -66,7 +66,7 @@
   font-weight: 700;
   font-size: 14;
   border-bottom-style: solid;
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   padding: 16px 0px 10px 0px;
   overflow: hidden;
   color: dimgray;
@@ -87,10 +87,8 @@
 
 .editorTitle {
   font-size: 16px;
-  font-weight: bold;
-  font-family: 'ui-monospace';
   border-bottom-style: solid;
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   padding-bottom: 12px;
   overflow: hidden;
 }
@@ -172,7 +170,7 @@
 .commentSidebarTitle {
   font-size: 16px;
   border-bottom-style: solid;
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   padding-bottom: 8px;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -223,18 +221,37 @@
 
 .commentEditButton {
   background-color: transparent;
+  color: #495057;
 }
 
 .commentDeleteButton {
   background-color: transparent;
+  color: #495057;
 }
 
 .commentFlagButton {
   background-color: transparent;
+  color: #495057;
 }
 
-.commentDeleteButton:hover {
-  background-color: #8a8a8a;
+.commentEditButton:hover,
+.commentDeleteButton:hover,
+.commentFlagButton:hover {
+  background-color: rgba(73, 80, 87, 0.2);
+  color: #343a40;
+}
+
+/* Keep icon contrast clear in dark mode as well */
+:global([data-mantine-color-scheme='dark']) .commentEditButton,
+:global([data-mantine-color-scheme='dark']) .commentDeleteButton,
+:global([data-mantine-color-scheme='dark']) .commentFlagButton {
+  color: #ced4da;
+}
+
+:global([data-mantine-color-scheme='dark']) .commentEditButton:hover,
+:global([data-mantine-color-scheme='dark']) .commentDeleteButton:hover,
+:global([data-mantine-color-scheme='dark']) .commentFlagButton:hover {
+  background-color: rgba(206, 212, 218, 0.14);
 }
 
 .commentText {


### PR DESCRIPTION
## Description

- Grading UI had a bug where grading can take place for submissions that are in draft. This should not be the case. Only submitted submissions can be graded.
- Flagging errors out even when grading is complete. Flagging should be enabled at any point in time.
- Repo tree should be expanded by default for usability.
- Submission status filter would be useful for TAs/Coordinators to see reviewers based on submission status.

## Changes

- Updated peer review comment service to support the flagging issue.
- Updated FE control to hide grading button when submission is in draft + change button name for greater intuitiveness.
- Updated repo tree render logic to show 1 level down by default when fetched.
- Added submission filter logic.

## Screenshots (if applicable)

<img width="1974" height="1084" alt="image" src="https://github.com/user-attachments/assets/db7c2157-2655-4ab5-9a7f-9e2eb3af53e6" />

Resolves #495, #496, #497, #498