### PR TITLE
Fix Flag Comment Flow + Refine UI

### DIFF
--- a/backend/services/peerReviewCommentsService.ts
+++ b/backend/services/peerReviewCommentsService.ts
@@ -244,11 +244,29 @@ export const updatePeerReviewCommentById = async (
   const comment = await PeerReviewCommentModel.findById(commentId);
   if (!comment) throw new NotFoundError(COMMENT_NOT_FOUND);
 
+  const trimmedUpdatedComment = updatedComment.trim();
+  const trimmedCurrentComment = comment.comment.trim();
+  const isContentChanged = trimmedUpdatedComment !== trimmedCurrentComment;
+
+  if (comment.isFlagged && !isContentChanged) {
+    throw new BadRequestError(
+      'Flagged comment must be revised before it can be resolved'
+    );
+  }
+
   // Faculty can update any comment
   if (userCourseRole === COURSE_ROLE.Faculty) {
-    if (updatedComment.trim().length === 0)
+    if (trimmedUpdatedComment.length === 0)
       throw new BadRequestError('Comment text cannot be empty');
     comment.comment = updatedComment;
+
+    if (comment.isFlagged && isContentChanged) {
+      comment.isFlagged = false;
+      comment.unflagReason = 'Resolved by reviewer update';
+      comment.unflaggedAt = new Date();
+      comment.unflaggedBy = oid(userId);
+    }
+
     comment.updatedAt = new Date();
     await comment.save();
     return;
@@ -272,9 +290,17 @@ export const updatePeerReviewCommentById = async (
     );
 
     if (isSupervisingTA && !taReviewerSubmission) {
-      if (updatedComment.trim().length === 0)
+      if (trimmedUpdatedComment.length === 0)
         throw new BadRequestError('Comment text cannot be empty');
       comment.comment = updatedComment;
+
+      if (comment.isFlagged && isContentChanged) {
+        comment.isFlagged = false;
+        comment.unflagReason = 'Resolved by reviewer update';
+        comment.unflaggedAt = new Date();
+        comment.unflaggedBy = oid(userId);
+      }
+
       comment.updatedAt = new Date();
       await comment.save();
       return;
@@ -313,10 +339,18 @@ export const updatePeerReviewCommentById = async (
       throw new MissingAuthorizationError(UNAUTHORIZED_TO_UPDATE_COMMENTS);
   }
 
-  if (updatedComment.trim().length === 0)
+  if (trimmedUpdatedComment.length === 0)
     throw new BadRequestError('Comment text cannot be empty');
 
   comment.comment = updatedComment;
+
+  if (comment.isFlagged && isContentChanged) {
+    comment.isFlagged = false;
+    comment.unflagReason = 'Resolved by reviewer update';
+    comment.unflaggedAt = new Date();
+    comment.unflaggedBy = oid(userId);
+  }
+
   comment.updatedAt = new Date();
   await comment.save();
   return;
@@ -501,17 +535,24 @@ const findCommentsForSubmissionVisible = async (
     .populate('author', '_id name')
     .lean();
 
-  return decorateCommentsForViewer(comments, userId, userCourseRole, false);
+  return decorateCommentsForViewer(comments, userId, userCourseRole, false, {
+    showFlaggedToStudents: true,
+  });
 };
 
 const decorateCommentsForViewer = async (
   comments: any[],
   userId: string,
   userCourseRole: string,
-  canModerateAll: boolean
+  canModerateAll: boolean,
+  options?: {
+    showFlaggedToStudents?: boolean;
+  }
 ) => {
+  const showFlaggedToStudents = Boolean(options?.showFlaggedToStudents);
+
   const visibleComments =
-    userCourseRole === COURSE_ROLE.Student
+    userCourseRole === COURSE_ROLE.Student && !showFlaggedToStudents
       ? comments.filter(comment => !comment.isFlagged)
       : comments;
 

--- a/backend/services/peerReviewCommentsService.ts
+++ b/backend/services/peerReviewCommentsService.ts
@@ -448,8 +448,22 @@ const fetchReviewee = async (teamId: string) => {
 };
 
 const findCommentsAnonymous = async (assignmentId: string) => {
+  const submittedSubmissionIds = (
+    await PeerReviewSubmissionModel.find({
+      peerReviewAssignmentId: assignmentId,
+      status: 'Submitted',
+    })
+      .select('_id')
+      .lean()
+  ).map(s => s._id);
+
+  if (submittedSubmissionIds.length === 0) {
+    return [];
+  }
+
   return PeerReviewCommentModel.find({
     peerReviewAssignmentId: assignmentId,
+    peerReviewSubmissionId: { $in: submittedSubmissionIds },
     isFlagged: { $ne: true },
   })
     .select('-author -flaggedBy') // hide identity

--- a/backend/test/services/peerReviewCommentsService.test.ts
+++ b/backend/test/services/peerReviewCommentsService.test.ts
@@ -353,6 +353,34 @@ describe('peerReviewCommentsService', () => {
       expect((res[0] as any).comment).toBe('submitted comment');
     });
 
+    it('Student (reviewee): returns empty array when there are no Submitted submissions', async () => {
+      const studentId = oid();
+      const pr = await makePeerReview();
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewee = await makeTeam({ members: [studentId] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+
+      const draftSubmission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: oidStr(),
+        status: 'Draft',
+      });
+
+      await makeComment(pr._id, assignment._id, {
+        comment: 'draft-only comment',
+        peerReviewSubmissionId: draftSubmission._id,
+      });
+
+      const res = await getPeerReviewCommentsByAssignmentId(
+        studentId.toString(),
+        COURSE_ROLE.Student,
+        assignment._id.toString()
+      );
+
+      expect(res).toEqual([]);
+    });
+
     it('TA supervising: returns visible comments', async () => {
       const taId = oid();
       const pr = await makePeerReview();
@@ -857,6 +885,129 @@ describe('peerReviewCommentsService', () => {
       const updated = await PeerReviewCommentModel.findById(comment._id);
       expect(updated?.comment).toBe('updated text');
       expect(updated?.updatedAt).toBeTruthy();
+    });
+
+    it('auto-unflags flagged comment when reviewer updates with changed content', async () => {
+      const pr = await makePeerReview();
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewerId = oid();
+      const reviewee = await makeTeam({ members: [oid()] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+
+      const submission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: reviewerId.toString(),
+      });
+
+      (fetchSubmissionForAssignment as jest.Mock).mockResolvedValue({
+        status: 'Draft',
+        reviewerKind: 'Student',
+        reviewerUserId: reviewerId.toString(),
+      });
+
+      const comment = await makeComment(pr._id, assignment._id, {
+        author: reviewerId,
+        peerReviewSubmissionId: submission._id,
+        comment: 'original flagged comment',
+        isFlagged: true,
+        flagReason: 'Please revise wording',
+      });
+
+      await expect(
+        updatePeerReviewCommentById(
+          reviewerId.toString(),
+          COURSE_ROLE.Student,
+          assignment._id.toString(),
+          comment._id.toString(),
+          'revised comment text',
+          submission._id.toString()
+        )
+      ).resolves.toBeUndefined();
+
+      const updated = await PeerReviewCommentModel.findById(comment._id);
+      expect(updated?.comment).toBe('revised comment text');
+      expect(updated?.isFlagged).toBe(false);
+      expect(updated?.unflaggedAt).toBeTruthy();
+      expect(updated?.unflagReason).toBe('Resolved by reviewer update');
+      expect(updated?.unflaggedBy?.toString()).toBe(reviewerId.toString());
+    });
+
+    it('Faculty auto-unflags flagged comment when updating with changed content', async () => {
+      const pr = await makePeerReview();
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewee = await makeTeam({ members: [oid()] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+
+      const comment = await makeComment(pr._id, assignment._id, {
+        author: oid(),
+        comment: 'faculty flagged comment',
+        isFlagged: true,
+        flagReason: 'Needs revision',
+      });
+
+      const facultyId = oid();
+      await expect(
+        updatePeerReviewCommentById(
+          facultyId.toString(),
+          COURSE_ROLE.Faculty,
+          assignment._id.toString(),
+          comment._id.toString(),
+          'faculty revised comment',
+          ''
+        )
+      ).resolves.toBeUndefined();
+
+      const updated = await PeerReviewCommentModel.findById(comment._id);
+      expect(updated?.comment).toBe('faculty revised comment');
+      expect(updated?.isFlagged).toBe(false);
+      expect(updated?.unflaggedAt).toBeTruthy();
+      expect(updated?.unflagReason).toBe('Resolved by reviewer update');
+      expect(updated?.unflaggedBy?.toString()).toBe(facultyId.toString());
+    });
+
+    it('keeps comment flagged when update text is unchanged', async () => {
+      const pr = await makePeerReview();
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewerId = oid();
+      const reviewee = await makeTeam({ members: [oid()] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+
+      const submission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: reviewerId.toString(),
+      });
+
+      (fetchSubmissionForAssignment as jest.Mock).mockResolvedValue({
+        status: 'Draft',
+        reviewerKind: 'Student',
+        reviewerUserId: reviewerId.toString(),
+      });
+
+      const comment = await makeComment(pr._id, assignment._id, {
+        author: reviewerId,
+        peerReviewSubmissionId: submission._id,
+        comment: 'unchanged flagged comment',
+        isFlagged: true,
+        flagReason: 'Needs revision',
+      });
+
+      await expect(
+        updatePeerReviewCommentById(
+          reviewerId.toString(),
+          COURSE_ROLE.Student,
+          assignment._id.toString(),
+          comment._id.toString(),
+          'unchanged flagged comment',
+          submission._id.toString()
+        )
+      ).rejects.toBeInstanceOf(BadRequestError);
+
+      const unchanged = await PeerReviewCommentModel.findById(comment._id);
+      expect(unchanged?.isFlagged).toBe(true);
+      expect(unchanged?.comment).toBe('unchanged flagged comment');
     });
 
     it('non-team reviewer cannot update another author\'s comment', async () => {
@@ -1368,7 +1519,7 @@ describe('peerReviewCommentsService edge cases', () => {
     expect(hasMyComment).toBe(true);
   });
 
-  it('Student + Individual reviewerType: hides flagged comments in submission view', async () => {
+  it('Student + Individual reviewerType: includes flagged comments in submission view for reviewer remediation', async () => {
     const studentId = new Types.ObjectId();
     const pr = await makePeerReview({ reviewerType: 'Individual' });
     (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
@@ -1401,9 +1552,9 @@ describe('peerReviewCommentsService edge cases', () => {
       assignment._id.toString()
     );
 
-    expect(res).toHaveLength(1);
-    expect(res[0].comment).toBe('visible comment');
-    expect(res[0].isFlagged).toBe(false);
+    expect(res).toHaveLength(2);
+    expect(res.some(c => c.comment === 'visible comment')).toBe(true);
+    expect(res.some(c => c.comment === 'flagged comment')).toBe(true);
   });
 
   it('Student + Team reviewerType: returns null when homeTeam not found (homeTeam branch)', async () => {
@@ -1802,6 +1953,39 @@ describe('peerReviewCommentsService edge cases', () => {
           ''
         )
       ).rejects.toBeInstanceOf(BadRequestError);
+    });
+
+    it('TA supervising auto-unflags flagged comment when updating with changed content', async () => {
+      const taId = oid();
+      const pr = await makePeerReview({ reviewerType: 'Individual' });
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewee = await makeTeam({ TA: taId, members: [oid()] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+      const comment = await makeComment(pr._id, assignment._id, {
+        author: oid(),
+        comment: 'ta flagged comment',
+        isFlagged: true,
+        flagReason: 'Revise this',
+      });
+
+      await expect(
+        updatePeerReviewCommentById(
+          taId.toString(),
+          COURSE_ROLE.TA,
+          assignment._id.toString(),
+          comment._id.toString(),
+          'ta revised comment',
+          ''
+        )
+      ).resolves.toBeUndefined();
+
+      const updated = await PeerReviewCommentModel.findById(comment._id);
+      expect(updated?.comment).toBe('ta revised comment');
+      expect(updated?.isFlagged).toBe(false);
+      expect(updated?.unflaggedAt).toBeTruthy();
+      expect(updated?.unflagReason).toBe('Resolved by reviewer update');
+      expect(updated?.unflaggedBy?.toString()).toBe(taId.toString());
     });
 
     it('Student + Team reviewer + no reviewerTeamId: throws MissingAuthorizationError', async () => {

--- a/backend/test/services/peerReviewCommentsService.test.ts
+++ b/backend/test/services/peerReviewCommentsService.test.ts
@@ -255,7 +255,16 @@ describe('peerReviewCommentsService', () => {
       const reviewee = await makeTeam({ members: [studentId] });
       const assignment = await makeAssignment(pr._id, reviewee._id);
 
-      const c = await makeComment(pr._id, assignment._id, { author: oid() });
+      const submittedSubmission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: oidStr(),
+        status: 'Submitted',
+      });
+
+      const c = await makeComment(pr._id, assignment._id, {
+        author: oid(),
+        peerReviewSubmissionId: submittedSubmission._id,
+      });
 
       const res = await getPeerReviewCommentsByAssignmentId(
         studentId.toString(),
@@ -278,14 +287,22 @@ describe('peerReviewCommentsService', () => {
       const reviewee = await makeTeam({ members: [studentId] });
       const assignment = await makeAssignment(pr._id, reviewee._id);
 
+      const submittedSubmission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: oidStr(),
+        status: 'Submitted',
+      });
+
       await makeComment(pr._id, assignment._id, {
         comment: 'visible comment',
         isFlagged: false,
+        peerReviewSubmissionId: submittedSubmission._id,
       });
       await makeComment(pr._id, assignment._id, {
         comment: 'hidden flagged comment',
         isFlagged: true,
         flagReason: 'Inappropriate language',
+        peerReviewSubmissionId: submittedSubmission._id,
       });
 
       const res = await getPeerReviewCommentsByAssignmentId(
@@ -296,6 +313,44 @@ describe('peerReviewCommentsService', () => {
 
       expect(res).toHaveLength(1);
       expect((res[0] as any).comment).toBe('visible comment');
+    });
+
+    it('Student (reviewee): does not see comments from Draft submissions', async () => {
+      const studentId = oid();
+      const pr = await makePeerReview();
+      (getPeerReviewById as jest.Mock).mockResolvedValue(pr);
+
+      const reviewee = await makeTeam({ members: [studentId] });
+      const assignment = await makeAssignment(pr._id, reviewee._id);
+
+      const draftSubmission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: oidStr(),
+        status: 'Draft',
+      });
+      const submittedSubmission = await makeSubmission(pr._id, assignment._id, {
+        reviewerKind: 'Student',
+        reviewerUserId: oidStr(),
+        status: 'Submitted',
+      });
+
+      await makeComment(pr._id, assignment._id, {
+        comment: 'draft comment',
+        peerReviewSubmissionId: draftSubmission._id,
+      });
+      await makeComment(pr._id, assignment._id, {
+        comment: 'submitted comment',
+        peerReviewSubmissionId: submittedSubmission._id,
+      });
+
+      const res = await getPeerReviewCommentsByAssignmentId(
+        studentId.toString(),
+        COURSE_ROLE.Student,
+        assignment._id.toString()
+      );
+
+      expect(res).toHaveLength(1);
+      expect((res[0] as any).comment).toBe('submitted comment');
     });
 
     it('TA supervising: returns visible comments', async () => {

--- a/multi-git-dashboard/src/components/cards/Modals/AssignGradersModal.tsx
+++ b/multi-git-dashboard/src/components/cards/Modals/AssignGradersModal.tsx
@@ -4,11 +4,16 @@ import {
   Stack,
   NumberInput,
   Switch,
+  Checkbox,
   Button,
   Group,
   Alert,
 } from '@mantine/core';
-import { IconAlertCircle, IconUserPlus } from '@tabler/icons-react';
+import {
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconUserPlus,
+} from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { getApiErrorMessage } from '@/lib/peer-review/utils';
 
@@ -32,10 +37,14 @@ const AssignGradersModal: React.FC<AssignGradersModalProps> = ({
     useState<boolean>(false);
   const [loading, setLoading] = useState(false);
   const [taCount, setTaCount] = useState<number>(0);
+  const [confirmDestructiveAction, setConfirmDestructiveAction] =
+    useState(false);
 
   // Fetch TA count for the course
   useEffect(() => {
     if (!opened || !courseId) return;
+
+    setConfirmDestructiveAction(false);
 
     const fetchTACount = async () => {
       try {
@@ -107,6 +116,11 @@ const AssignGradersModal: React.FC<AssignGradersModalProps> = ({
           This will assign TAs as graders to all peer review submissions.
         </Alert>
 
+        <Alert icon={<IconAlertTriangle />} color="red" variant="light">
+          Warning: Re-assigning graders will delete all existing grades and
+          feedback for this assessment.
+        </Alert>
+
         <NumberInput
           label="Graders per submission"
           description={`Select between 1 and ${taCount} graders.`}
@@ -125,12 +139,18 @@ const AssignGradersModal: React.FC<AssignGradersModalProps> = ({
           onChange={e => setAllowSupervisingTAs(e.currentTarget.checked)}
         />
 
+        <Checkbox
+          label="I understand that existing grades and feedback will be permanently deleted."
+          checked={confirmDestructiveAction}
+          onChange={e => setConfirmDestructiveAction(e.currentTarget.checked)}
+        />
+
         <Group justify="flex-end" mt="md">
           <Button
             leftSection={<IconUserPlus size={16} />}
             onClick={handleAssign}
             loading={loading}
-            disabled={taCount === 0}
+            disabled={taCount === 0 || !confirmDestructiveAction}
           >
             Assign Graders
           </Button>

--- a/multi-git-dashboard/src/components/cards/Modals/FlaggedCommentsModal.tsx
+++ b/multi-git-dashboard/src/components/cards/Modals/FlaggedCommentsModal.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {
+  Modal,
+  Stack,
+  Alert,
+  Text,
+  ScrollAreaAutosize,
+  Card,
+  Group,
+  Badge,
+  Button,
+} from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { PeerReviewComment } from '@shared/types/PeerReview';
+
+interface FlaggedCommentsModalProps {
+  opened: boolean;
+  onClose: () => void;
+  isSubmitted: boolean;
+  comments: PeerReviewComment[];
+  onOpenComment: (comment: PeerReviewComment) => void;
+}
+
+const FlaggedCommentsModal: React.FC<FlaggedCommentsModalProps> = ({
+  opened,
+  onClose,
+  isSubmitted,
+  comments,
+  onOpenComment,
+}) => {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Flagged Comments Requiring Action"
+      size="lg"
+      centered
+    >
+      <Stack gap="md">
+        <Alert
+          color="orange"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+        >
+          {isSubmitted
+            ? 'Your review has been submitted. Flagged comments are read-only, take note of the reasons before the next peer review.'
+            : 'Please revise and update these comments.'}
+        </Alert>
+
+        <Text size="sm" c="dimmed">
+          {comments.length} flagged comment
+          {comments.length === 1 ? '' : 's'} found.
+        </Text>
+
+        <ScrollAreaAutosize
+          mah={320}
+          offsetScrollbars={false}
+          styles={{ viewport: { overflowX: 'hidden' } }}
+        >
+          <Stack gap="sm" style={{ minWidth: 0, overflowX: 'hidden' }}>
+            {comments.map(comment => (
+              <Card
+                key={comment._id}
+                withBorder
+                radius="md"
+                p="sm"
+                style={{ overflow: 'hidden', maxWidth: '100%', width: '100%' }}
+              >
+                <Group justify="space-between" align="center" mb={6}>
+                  <Badge variant="light" color="blue">
+                    {comment.filePath} ({comment.startLine}-{comment.endLine})
+                  </Badge>
+                  <Button
+                    size="compact-xs"
+                    variant="subtle"
+                    onClick={() => onOpenComment(comment)}
+                  >
+                    Open
+                  </Button>
+                </Group>
+
+                <Text
+                  size="sm"
+                  mb={6}
+                  title={comment.comment}
+                  style={{
+                    width: 0,
+                    minWidth: '100%',
+                    maxWidth: '100%',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {comment.comment}
+                </Text>
+
+                <Text
+                  size="xs"
+                  c="orange"
+                  fw={500}
+                  style={{
+                    whiteSpace: 'pre-wrap',
+                    overflowWrap: 'anywhere',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  Reason: {comment.flagReason?.trim() || 'No reason provided.'}
+                </Text>
+              </Card>
+            ))}
+          </Stack>
+        </ScrollAreaAutosize>
+      </Stack>
+    </Modal>
+  );
+};
+
+export default FlaggedCommentsModal;

--- a/multi-git-dashboard/src/components/cards/Modals/PeerReviewGradingSummaryModal.tsx
+++ b/multi-git-dashboard/src/components/cards/Modals/PeerReviewGradingSummaryModal.tsx
@@ -48,11 +48,6 @@ const PeerReviewGradingSummaryModal: React.FC<
                     <Text fw={600} size="sm">
                       {isFaculty ? task.grader.name : 'Your Grade'}
                     </Text>
-                    {isFaculty && (
-                      <Text size="xs" c="dimmed">
-                        Grader ID: {task.grader.id}
-                      </Text>
-                    )}
                   </Stack>
                   <Badge
                     variant="light"

--- a/multi-git-dashboard/src/components/forms/CreateAssessmentForm.tsx
+++ b/multi-git-dashboard/src/components/forms/CreateAssessmentForm.tsx
@@ -5,21 +5,44 @@ import UploadGoogleCSV from './UploadGoogleAssessmentFormCsv';
 import UploadInternalCSV from './UploadInternalAssessmentFormCsv';
 import { TeamSet } from '@shared/types/TeamSet';
 import CreatePeerReviewForm from './CreatePeerReviewForm';
+import { useEffect, useState } from 'react';
+
+type CreateAssessmentTabValue =
+  | 'internal'
+  | 'peerReview'
+  | 'internalCsv'
+  | 'googleForms'
+  | 'googleCsv';
 
 interface CreateAssessmentFormProps {
   courseId: string | string[] | undefined;
   onAssessmentCreated: () => void;
   teamSets: TeamSet[];
+  initialTab?: CreateAssessmentTabValue;
 }
 
 const CreateAssessmentForm: React.FC<CreateAssessmentFormProps> = ({
   courseId,
   onAssessmentCreated,
   teamSets,
+  initialTab = 'internal',
 }) => {
+  const [activeTab, setActiveTab] =
+    useState<CreateAssessmentTabValue>(initialTab);
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
   return (
     <Box mx="auto">
-      <Tabs defaultValue="internal" variant="outline">
+      <Tabs
+        value={activeTab}
+        onChange={value =>
+          setActiveTab((value as CreateAssessmentTabValue) || 'internal')
+        }
+        variant="outline"
+      >
         <Tabs.List justify="center">
           <Tabs.Tab value="internal">Internal Form</Tabs.Tab>
           <Tabs.Tab value="peerReview">Peer Review</Tabs.Tab>

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAccordianItem.tsx
@@ -74,6 +74,7 @@ const PeerReviewAccordionItem = forwardRef<
     deleteManualAssignment,
   }) => {
     const router = useRouter();
+    const peerReviewBasePath = router.asPath.split('?')[0].split('#')[0];
 
     const [
       openedDeleteModal,
@@ -324,7 +325,7 @@ const PeerReviewAccordionItem = forwardRef<
                           onClick={() => {
                             if (!canViewPeerReview || !assignmentId) return;
                             router.push(
-                              `${router.asPath.replace(/\/$/, '')}/${assignmentId}`
+                              `${peerReviewBasePath.replace(/\/$/, '')}/${assignmentId}`
                             );
                           }}
                           size="xs"

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewAssignments.tsx
@@ -26,6 +26,7 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
   onDelete,
 }) => {
   const router = useRouter();
+  const peerReviewBasePath = router.asPath.split('?')[0].split('#')[0];
 
   const filteredAssignments = assignments.filter(a =>
     statusFilters.length === 0 ? true : statusFilters.includes(a.status)
@@ -81,7 +82,7 @@ const PeerReviewAssignments: React.FC<PeerReviewAssignmentsProps> = ({
               disabled={disableNavigation}
               onClick={() =>
                 router.push(
-                  `${router.asPath.replace(/\/$/, '')}/${a.assignment._id}`
+                  `${peerReviewBasePath.replace(/\/$/, '')}/${a.assignment._id}`
                 )
               }
             >

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewCommentSidebar.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewCommentSidebar.tsx
@@ -231,7 +231,7 @@ const PeerReviewCommentSidebar: React.FC<PeerReviewCommentSidebarProps> = ({
                         {c.updatedAt &&
                           new Date(c.updatedAt).toLocaleDateString()}
                       </Text>
-                      {isStaffViewer && c.isFlagged && !c.unflaggedAt && (
+                      {c.isFlagged && !c.unflaggedAt && (
                         <Popover
                           width={240}
                           position="bottom-start"
@@ -247,7 +247,9 @@ const PeerReviewCommentSidebar: React.FC<PeerReviewCommentSidebarProps> = ({
                               className={classes.flaggedIndicatorButton}
                               onClick={event => event.stopPropagation()}
                             >
-                              Flagged
+                              {isStaffViewer
+                                ? 'Flagged'
+                                : 'Flagged for revision'}
                             </Button>
                           </Popover.Target>
                           <Popover.Dropdown

--- a/multi-git-dashboard/src/components/peer-review/PeerReviewSettings.tsx
+++ b/multi-git-dashboard/src/components/peer-review/PeerReviewSettings.tsx
@@ -163,7 +163,12 @@ const PeerReviewSettings: React.FC<PeerReviewSettingsProps> = ({
           <Button
             color="yellow"
             variant="light"
-            onClick={() => router.push(`/courses/${courseId}/peer-review`)}
+            onClick={() =>
+              router.push({
+                pathname: `/courses/${courseId}/peer-review`,
+                query: { peerReviewId: peerReview._id },
+              })
+            }
           >
             {!isFaculty
               ? 'Monitor Your Teams'

--- a/multi-git-dashboard/src/components/views/AssessmentsInfo.tsx
+++ b/multi-git-dashboard/src/components/views/AssessmentsInfo.tsx
@@ -11,12 +11,20 @@ import {
 import { Assessment } from '@shared/types/Assessment';
 import { InternalAssessment } from '@shared/types/InternalAssessment';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AssessmentCard from '../cards/AssessmentCard';
 import CreateAssessmentForm from '../forms/CreateAssessmentForm';
 import InternalAssessmentCard from '../cards/InternalAssessmentCard';
 import TutorialPopover from '../tutorial/TutorialPopover';
 import { TeamSet } from '@shared/types/TeamSet';
+import { useRouter } from 'next/router';
+
+type CreateAssessmentTabValue =
+  | 'internal'
+  | 'peerReview'
+  | 'internalCsv'
+  | 'googleForms'
+  | 'googleCsv';
 
 interface AssessmentInfoProps {
   courseId: string;
@@ -33,12 +41,62 @@ const AssessmentInfo: React.FC<AssessmentInfoProps> = ({
   teamSets,
   onUpdate,
 }) => {
+  const router = useRouter();
+  const isFaculty = hasFacultyPermission();
   console.log(internalAssessments);
   const [isCreatingAssessment, setIsCreatingAssessment] = useState(false);
+  const [createAssessmentTab, setCreateAssessmentTab] =
+    useState<CreateAssessmentTabValue>('internal');
 
-  const toggleForm = () => {
-    setIsCreatingAssessment(o => !o);
+  const openCreateAssessmentModal = (
+    tab: CreateAssessmentTabValue = 'internal'
+  ) => {
+    setCreateAssessmentTab(tab);
+    setIsCreatingAssessment(true);
   };
+
+  const closeCreateAssessmentModal = () => {
+    setIsCreatingAssessment(false);
+  };
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!isFaculty) return;
+
+    const openCreateAssessment = router.query.openCreateAssessment;
+    const requestedTab = router.query.createAssessmentTab;
+
+    const shouldOpen =
+      openCreateAssessment === '1' || openCreateAssessment === 'true';
+
+    if (!shouldOpen) return;
+
+    const validTabs: CreateAssessmentTabValue[] = [
+      'internal',
+      'peerReview',
+      'internalCsv',
+      'googleForms',
+      'googleCsv',
+    ];
+
+    const requestedTabValue =
+      typeof requestedTab === 'string' &&
+      validTabs.includes(requestedTab as CreateAssessmentTabValue)
+        ? (requestedTab as CreateAssessmentTabValue)
+        : 'internal';
+
+    openCreateAssessmentModal(requestedTabValue);
+
+    const cleanedQuery = { ...router.query };
+    delete cleanedQuery.openCreateAssessment;
+    delete cleanedQuery.createAssessmentTab;
+
+    router.replace(
+      { pathname: router.pathname, query: cleanedQuery },
+      undefined,
+      { shallow: true }
+    );
+  }, [router.isReady, router.query, isFaculty]);
 
   const handleAssessmentCreated = () => {
     setIsCreatingAssessment(false);
@@ -87,14 +145,16 @@ const AssessmentInfo: React.FC<AssessmentInfoProps> = ({
 
   return (
     <Container>
-      {hasFacultyPermission() && (
+      {isFaculty && (
         <Group style={{ marginBottom: '16px', marginTop: '16px' }}>
-          <Button onClick={toggleForm}>Create Assessment</Button>
+          <Button onClick={() => openCreateAssessmentModal('internal')}>
+            Create Assessment
+          </Button>
         </Group>
       )}
       <Modal
         opened={isCreatingAssessment}
-        onClose={toggleForm}
+        onClose={closeCreateAssessmentModal}
         title="Create Assessment"
         size="xl"
       >
@@ -102,6 +162,7 @@ const AssessmentInfo: React.FC<AssessmentInfoProps> = ({
           teamSets={teamSets}
           courseId={courseId}
           onAssessmentCreated={handleAssessmentCreated}
+          initialTab={createAssessmentTab}
         />
       </Modal>
 

--- a/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewInfo.tsx
@@ -61,29 +61,6 @@ const NotificationTypeToColorMap: Record<NotificationType, string> = {
   [NotificationType.Warning]: 'yellow',
 };
 
-const usePersistedAccordion = (key: string, validValues: string[]) => {
-  const [opened, setOpened] = useState<string[]>(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem(key) || '[]');
-      return Array.isArray(saved)
-        ? saved.filter(v => validValues.includes(v))
-        : [];
-    } catch {
-      return [];
-    }
-  });
-
-  useEffect(() => {
-    localStorage.setItem(key, JSON.stringify(opened));
-  }, [key, opened]);
-
-  useEffect(() => {
-    setOpened(prev => prev.filter(v => validValues.includes(v)));
-  }, [validValues]);
-
-  return [opened, setOpened] as const;
-};
-
 const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
   courseId,
   teamSets,
@@ -165,14 +142,75 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
 
   // Persist Accordion State
   const values = useMemo(() => {
-    const items = peerReviewInfo?.teams.map(t => t.teamId) || [];
-    if (peerReview.taAssignments) items.push('teaching-assistants');
+    const items: string[] = [];
+    if ((isFaculty || isTA) && peerReviewInfo) {
+      items.push('progress');
+    }
+    if ((isFaculty || isTA) && peerReview.taAssignments) {
+      items.push('teaching-assistants');
+    }
+    const teamItems = peerReviewInfo?.teams.map(t => t.teamId) || [];
+    items.push(...teamItems);
     return items;
-  }, [peerReviewInfo]);
-  const [opened, setOpened] = usePersistedAccordion(
-    'peer-review-accordion',
-    values
-  );
+  }, [peerReviewInfo, isFaculty, isTA, peerReview.taAssignments]);
+
+  const accordionStorageKey = `peer-review-accordion-${peerReview._id}`;
+  const [opened, setOpened] = useState<string[]>([]);
+  const [hydratedAccordionKey, setHydratedAccordionKey] = useState<
+    string | null
+  >(null);
+  const [hasSavedAccordionState, setHasSavedAccordionState] = useState(false);
+
+  // Load persisted accordion state once per peer review
+  useEffect(() => {
+    setHydratedAccordionKey(null);
+
+    try {
+      const saved = localStorage.getItem(accordionStorageKey);
+      setHasSavedAccordionState(saved !== null);
+
+      if (!saved) {
+        setOpened([]);
+      } else {
+        const parsed = JSON.parse(saved);
+        setOpened(Array.isArray(parsed) ? parsed : []);
+      }
+    } catch {
+      setHasSavedAccordionState(false);
+      setOpened([]);
+    } finally {
+      setHydratedAccordionKey(accordionStorageKey);
+    }
+  }, [accordionStorageKey]);
+
+  // Reconcile open items after values are known
+  useEffect(() => {
+    if (hydratedAccordionKey !== accordionStorageKey) return;
+    if (!peerReviewInfo) return;
+
+    setOpened(prev => {
+      const filtered = prev.filter(v => values.includes(v));
+
+      if (filtered.length > 0) return filtered;
+      if (hasSavedAccordionState) return [];
+
+      // First visit: open first available item by default
+      return values.slice(0, 1);
+    });
+  }, [
+    values,
+    peerReviewInfo,
+    hydratedAccordionKey,
+    accordionStorageKey,
+    hasSavedAccordionState,
+  ]);
+
+  // Persist whenever state changes after hydration
+  useEffect(() => {
+    if (hydratedAccordionKey !== accordionStorageKey) return;
+    if (!peerReviewInfo) return;
+    localStorage.setItem(accordionStorageKey, JSON.stringify(opened));
+  }, [opened, accordionStorageKey, hydratedAccordionKey, peerReviewInfo]);
 
   const myTAReviewerAssignmentIds = useMemo(() => {
     if (!isTA || !me?.userId || !peerReviewInfo?.TAAssignments)
@@ -507,7 +545,6 @@ const PeerReviewInfo: React.FC<PeerReviewInfoProps> = ({
       ) : isFaculty || peerReview.status === 'Active' ? (
         <>
           <Accordion
-            defaultValue={['teaching-assistants']}
             value={opened}
             onChange={setOpened}
             multiple

--- a/multi-git-dashboard/src/components/views/PeerReviewOverview.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewOverview.tsx
@@ -1,9 +1,16 @@
-import { Tabs, Container, ScrollArea } from '@mantine/core';
+import {
+  Tabs,
+  Container,
+  ScrollArea,
+  ActionIcon,
+  Tooltip,
+} from '@mantine/core';
 import { TeamSet } from '@shared/types/TeamSet';
 import { PeerReview } from '@shared/types/PeerReview';
 import PeerReviewInfo from './PeerReviewInfo';
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
+import { IconPlus } from '@tabler/icons-react';
 
 interface PeerReviewOverviewProps {
   courseId: string;
@@ -75,36 +82,70 @@ const PeerReviewOverview: React.FC<PeerReviewOverviewProps> = ({
     }
   };
 
+  const goToCreatePeerReviewAssessment = () => {
+    router.push({
+      pathname: `/courses/${courseId}/assessments`,
+      query: {
+        openCreateAssessment: '1',
+        createAssessmentTab: 'peerReview',
+      },
+    });
+  };
+
   return (
     <Container>
       <Tabs mt="md" value={activeTab} onChange={handleTabChange}>
-        <Tabs.List
+        <div
           style={{
+            display: 'flex',
             justifyContent: 'center',
+            alignItems: 'center',
+            gap: '12px',
           }}
         >
-          {courseId && peerReviews.length > 0 ? (
-            peerReviews.map(pr => (
-              <Tabs.Tab
-                key={pr._id}
-                value={pr._id}
-                style={{
-                  padding: '10px 16px',
-                  fontWeight: 500,
-                  fontSize: '14px',
-                  transition: 'all 150ms ease',
-                  cursor: 'pointer',
-                }}
-              >
-                {pr.title}
+          <Tabs.List
+            style={{
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            {courseId && peerReviews.length > 0 ? (
+              peerReviews.map(pr => (
+                <Tabs.Tab
+                  key={pr._id}
+                  value={pr._id}
+                  style={{
+                    padding: '10px 16px',
+                    fontWeight: 500,
+                    fontSize: '14px',
+                    transition: 'all 150ms ease',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {pr.title}
+                </Tabs.Tab>
+              ))
+            ) : (
+              <Tabs.Tab key={'default'} value={'default'}>
+                No Peer Reviews Available
               </Tabs.Tab>
-            ))
-          ) : (
-            <Tabs.Tab key={'default'} value={'default'}>
-              No Peer Reviews Available
-            </Tabs.Tab>
+            )}
+          </Tabs.List>
+
+          {isFaculty && (
+            <Tooltip label="Create Peer Review Assessment" withArrow>
+              <ActionIcon
+                variant="light"
+                color="blue"
+                size="md"
+                onClick={goToCreatePeerReviewAssessment}
+                aria-label="Create Peer Review Assessment"
+              >
+                <IconPlus size={16} />
+              </ActionIcon>
+            </Tooltip>
           )}
-        </Tabs.List>
+        </div>
 
         {peerReviews.map(pr => (
           <Tabs.Panel key={pr._id} value={pr._id} pt="xs">

--- a/multi-git-dashboard/src/components/views/PeerReviewOverview.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewOverview.tsx
@@ -2,6 +2,8 @@ import { Tabs, Container, ScrollArea } from '@mantine/core';
 import { TeamSet } from '@shared/types/TeamSet';
 import { PeerReview } from '@shared/types/PeerReview';
 import PeerReviewInfo from './PeerReviewInfo';
+import { useState, useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 
 interface PeerReviewOverviewProps {
   courseId: string;
@@ -18,11 +20,64 @@ const PeerReviewOverview: React.FC<PeerReviewOverviewProps> = ({
   isFaculty,
   onUpdate,
 }) => {
+  const router = useRouter();
   const defaultTab = peerReviews[0]?._id || 'default';
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+  const handledRequestedTabRef = useRef<string | null>(null);
+  const requestedPeerReviewTab =
+    typeof router.query.peerReviewId === 'string'
+      ? router.query.peerReviewId
+      : null;
+
+  useEffect(() => {
+    // Priority: explicit tab from navigation query > current valid tab > saved tab > default
+    if (
+      requestedPeerReviewTab &&
+      handledRequestedTabRef.current !== requestedPeerReviewTab
+    ) {
+      if (peerReviews.length === 0) {
+        return;
+      }
+
+      const requestedExists = peerReviews.some(
+        pr => pr._id === requestedPeerReviewTab
+      );
+      if (requestedExists) {
+        handledRequestedTabRef.current = requestedPeerReviewTab;
+        setActiveTab(requestedPeerReviewTab);
+        localStorage.setItem(
+          `activePeerReviewTab_${courseId}`,
+          requestedPeerReviewTab
+        );
+        return;
+      }
+
+      // Query tab does not exist in loaded data; mark as handled and fall back below
+      handledRequestedTabRef.current = requestedPeerReviewTab;
+    }
+
+    if (activeTab && peerReviews.some(pr => pr._id === activeTab)) {
+      return;
+    }
+
+    const savedTab = localStorage.getItem(`activePeerReviewTab_${courseId}`);
+    if (savedTab && peerReviews.some(pr => pr._id === savedTab)) {
+      setActiveTab(savedTab);
+    } else {
+      setActiveTab(defaultTab);
+    }
+  }, [courseId, defaultTab, peerReviews, requestedPeerReviewTab, activeTab]);
+
+  const handleTabChange = (tabValue: string | null) => {
+    if (tabValue) {
+      setActiveTab(tabValue);
+      localStorage.setItem(`activePeerReviewTab_${courseId}`, tabValue);
+    }
+  };
 
   return (
     <Container>
-      <Tabs mt="md" defaultValue={defaultTab}>
+      <Tabs mt="md" value={activeTab} onChange={handleTabChange}>
         <Tabs.List
           style={{
             justifyContent: 'center',
@@ -30,7 +85,17 @@ const PeerReviewOverview: React.FC<PeerReviewOverviewProps> = ({
         >
           {courseId && peerReviews.length > 0 ? (
             peerReviews.map(pr => (
-              <Tabs.Tab key={pr._id} value={pr._id}>
+              <Tabs.Tab
+                key={pr._id}
+                value={pr._id}
+                style={{
+                  padding: '10px 16px',
+                  fontWeight: 500,
+                  fontSize: '14px',
+                  transition: 'all 150ms ease',
+                  cursor: 'pointer',
+                }}
+              >
                 {pr.title}
               </Tabs.Tab>
             ))

--- a/multi-git-dashboard/src/lib/peer-review/api.ts
+++ b/multi-git-dashboard/src/lib/peer-review/api.ts
@@ -177,7 +177,14 @@ export const apiUpdateComment = async (
       body: JSON.stringify({ comment: updatedComment, submissionId }),
     });
     if (!response.ok) {
-      throw new Error('Failed to update comment');
+      let message = 'Failed to update comment';
+      try {
+        const data = await response.json();
+        if (data?.message) message = data.message;
+      } catch {
+        // ignore body parse failures and keep default message
+      }
+      throw new Error(message);
     }
     return;
   } catch (err) {

--- a/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
@@ -12,6 +12,7 @@ import {
   Card,
   Button,
   Badge,
+  Alert,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useColorScheme } from '@mantine/hooks';
@@ -22,6 +23,7 @@ import {
   IconArrowLeft,
   IconSend,
   IconClipboardList,
+  IconAlertTriangle,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState, useRef } from 'react';
@@ -42,6 +44,7 @@ import SubmissionStatusBadge from '@/components/peer-review/SubmissionStatusBadg
 import SaveStateBadge from '@/components/peer-review/SaveStateBadge';
 import SubmitReviewConfirmationModal from '@/components/cards/Modals/SubmitReviewConfirmationModal';
 import PeerReviewSummaryModal from '@/components/cards/Modals/PeerReviewSummaryModal';
+import FlaggedCommentsModal from '@/components/cards/Modals/FlaggedCommentsModal';
 import { COURSE_ROLE } from '@shared/types/auth/CourseRole';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
@@ -137,6 +140,9 @@ const PeerReviewDetail: React.FC = () => {
   const [unflagCommentId, setUnflagCommentId] = useState<string | null>(null);
   const [submitReviewModalOpened, setSubmitReviewModalOpened] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [flaggedCommentsModalOpened, setFlaggedCommentsModalOpened] =
+    useState(false);
+  const hasShownFlaggedModalRef = useRef(false);
 
   type ActiveWidget = { start: number; end: number; top: number } | null;
   const [activeWidget, setActiveWidget] = useState<ActiveWidget>(null);
@@ -155,6 +161,31 @@ const PeerReviewDetail: React.FC = () => {
   useEffect(() => {
     currFileRef.current = currFile;
   }, [currFile]);
+
+  useEffect(() => {
+    hasShownFlaggedModalRef.current = false;
+  }, [peerReviewAssignmentId]);
+
+  const isReviewerConsole =
+    !isReviewee &&
+    Boolean(submission) &&
+    (me?.userCourseRole === COURSE_ROLE.Student ||
+      me?.userCourseRole === COURSE_ROLE.TA);
+  const flaggedCommentsForReviewer = comments.filter(
+    c => c.isFlagged && !c.unflaggedAt
+  );
+
+  useEffect(() => {
+    if (!isReviewerConsole) return;
+
+    if (
+      flaggedCommentsForReviewer.length > 0 &&
+      !hasShownFlaggedModalRef.current
+    ) {
+      hasShownFlaggedModalRef.current = true;
+      setFlaggedCommentsModalOpened(true);
+    }
+  }, [isReviewerConsole, flaggedCommentsForReviewer.length]);
 
   /* ===== Helper Functions ===== */
   const renderFocusedAndStaticDecos = useCallback(
@@ -454,7 +485,22 @@ const PeerReviewDetail: React.FC = () => {
 
       const currComment = comments.find(c => c._id === commentId);
       if (!currComment) return false;
-      if (currComment.comment === newComment) return true;
+      const unchanged = currComment.comment.trim() === newComment.trim();
+      const isFlagged = Boolean(
+        currComment.isFlagged && !currComment.unflaggedAt
+      );
+
+      if (unchanged && isFlagged) {
+        notifications.show({
+          color: 'orange',
+          title: 'Comment still flagged',
+          message:
+            'Please revise the comment text before updating to resolve moderation.',
+        });
+        return false;
+      }
+
+      if (unchanged) return true;
 
       try {
         setUpdatingCommentId(commentId);
@@ -581,6 +627,18 @@ const PeerReviewDetail: React.FC = () => {
       editorRef.current?.revealLineInCenter?.(comment.startLine);
     },
     [renderFocusedAndStaticDecos]
+  );
+
+  const handleOpenFlaggedComment = useCallback(
+    async (comment: PeerReviewComment) => {
+      await openFile(comment.filePath);
+      setFlaggedCommentsModalOpened(false);
+      setTimeout(() => {
+        renderFocusedAndStaticDecos([comment._id]);
+        editorRef.current?.revealLineInCenter?.(comment.startLine);
+      }, 120);
+    },
+    [openFile, renderFocusedAndStaticDecos]
   );
 
   const handleSubmitReview = useCallback(async () => {
@@ -775,6 +833,30 @@ const PeerReviewDetail: React.FC = () => {
           {actionElement}
         </Group>
       </Group>
+      {isReviewerConsole && flaggedCommentsForReviewer.length > 0 && (
+        <Alert
+          icon={<IconAlertTriangle size={16} />}
+          color="orange"
+          variant="light"
+          mb="sm"
+        >
+          <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
+            <Text size="sm" style={{ flex: 1 }}>
+              {isSubmitted
+                ? `You have ${flaggedCommentsForReviewer.length} flagged comment(s). This review has already been submitted, take note for future peer reviews.`
+                : `You have ${flaggedCommentsForReviewer.length} flagged comment(s) that require revision.`}
+            </Text>
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="orange"
+              onClick={() => setFlaggedCommentsModalOpened(true)}
+            >
+              View flagged comments
+            </Button>
+          </Group>
+        </Alert>
+      )}
       <Group className={classes.body}>
         <Box className={classes.repositoryBox}>
           <Text className={classes.repositoryTitle}>Repository</Text>
@@ -891,6 +973,13 @@ const PeerReviewDetail: React.FC = () => {
           title="Unflag Comment?"
           confirmLabel="Unflag"
           confirmColor="blue"
+        />
+        <FlaggedCommentsModal
+          opened={flaggedCommentsModalOpened}
+          onClose={() => setFlaggedCommentsModalOpened(false)}
+          isSubmitted={Boolean(isSubmitted)}
+          comments={flaggedCommentsForReviewer}
+          onOpenComment={handleOpenFlaggedComment}
         />
       </Group>
     </Container>

--- a/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
+++ b/multi-git-dashboard/src/pages/courses/[id]/peer-review/[peerReviewAssignmentId].tsx
@@ -642,6 +642,23 @@ const PeerReviewDetail: React.FC = () => {
   );
 
   const handleSubmitReview = useCallback(async () => {
+    const hasBlockingFlaggedComments =
+      isReviewerConsole &&
+      submission?.status !== 'Submitted' &&
+      flaggedCommentsForReviewer.length > 0;
+
+    if (hasBlockingFlaggedComments) {
+      setSubmitReviewModalOpened(false);
+      setFlaggedCommentsModalOpened(true);
+      notifications.show({
+        color: 'orange',
+        title: 'Resolve flagged comments first',
+        message:
+          'You must revise all flagged comments before submitting your review.',
+      });
+      return;
+    }
+
     try {
       setSubmitting(true);
       await submitReview();
@@ -662,7 +679,14 @@ const PeerReviewDetail: React.FC = () => {
     } finally {
       setSubmitting(false);
     }
-  }, [submitReview, router, id]);
+  }, [
+    submitReview,
+    router,
+    id,
+    isReviewerConsole,
+    submission?.status,
+    flaggedCommentsForReviewer.length,
+  ]);
 
   if (loading || !me)
     return (
@@ -742,6 +766,8 @@ const PeerReviewDetail: React.FC = () => {
     me.userCourseRole === COURSE_ROLE.Student ||
     me.userCourseRole === COURSE_ROLE.TA;
   const isSubmitted = submission?.status === 'Submitted';
+  const hasBlockingFlaggedComments =
+    isReviewerConsole && !isSubmitted && flaggedCommentsForReviewer.length > 0;
 
   const showSupervisorSummaryButton =
     !isReadOnly && !submission && isSupervisorTA && isFacultyOrTA;
@@ -782,7 +808,14 @@ const PeerReviewDetail: React.FC = () => {
       fz="sm"
       h="27px"
       disabled={!canEdit}
-      onClick={() => setSubmitReviewModalOpened(true)}
+      onClick={() => {
+        if (hasBlockingFlaggedComments) {
+          setSubmitReviewModalOpened(false);
+          setFlaggedCommentsModalOpened(true);
+          return;
+        }
+        setSubmitReviewModalOpened(true);
+      }}
     >
       Submit Review
     </Button>

--- a/multi-git-dashboard/src/styles/PeerReview.module.css
+++ b/multi-git-dashboard/src/styles/PeerReview.module.css
@@ -1,6 +1,12 @@
 .wrapper {
   padding: 20px;
   max-width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .wrapper :global(.monaco-editor .margin .glyph-margin) {
@@ -80,9 +86,12 @@
 }
 
 .body {
-  height: 90vh;
+  flex: 1;
+  min-height: 0;
+  max-height: 100%;
   gap: 8px;
   align-items: stretch;
+  overflow: hidden;
 }
 
 .editorTitle {


### PR DESCRIPTION
## Description

After user testing with a course coordinator, some feedback was provided:
- Should include a way to create peer review in the peer review tab
- Flag comment flow is minimal and requires notifying the reviewer
- Previously opened peer review tab should remain open on refresh

After a revisit, some improvements were identified as well:
- Removal of grader ID from grading summary as it is not useful
- Reviewees should only see submitted comments, and not those in drafts
- When assigning graders, coordinators should be warned of clear-state

## Changes

- Create peer review button added in peer review tab
- Previously opened peer review tab are not open by default using local storage
- Flagged comments are not visible to reviewers and alerts are shown
- Reviewers can now update the flagged comments and flag status is removed (minimal solution)
- Reviewers cannot submit reviews when there are flagged comments
- Grader IDs removed from grading summary
- Reviewees now see only submitted comments
- Warning is given to coordinators when assigning graders

## Screenshots (if applicable)

<img width="1814" height="1140" alt="image" src="https://github.com/user-attachments/assets/9ef8c738-77db-4e03-a825-386a5c704125" />
<img width="1532" height="1278" alt="image" src="https://github.com/user-attachments/assets/a18fed82-860b-4591-beea-43764679240b" />
<img width="2598" height="1604" alt="image" src="https://github.com/user-attachments/assets/8267e7f1-2b12-432f-988c-45fb73c21224" />

Resolves #500, #501, #502, #503, #504, #505, #506