### PR TITLE
Fix Grader Assignment Logic

### DIFF
--- a/backend/services/peerReviewGradingTaskService.ts
+++ b/backend/services/peerReviewGradingTaskService.ts
@@ -21,14 +21,20 @@ const NOT_ASSIGNED = 'Not assigned to grade this submission';
 
 const assertPeerReviewActive = async (peerReviewId: Types.ObjectId) => {
   const pr = await PeerReviewModel.findById(peerReviewId).select(
-    'startDate endDate status'
+    'startDate endDate gradingStartDate gradingEndDate status'
   );
   if (!pr) throw new NotFoundError('Peer review not found');
 
-  if (pr.status !== 'Active') {
+  if (pr.status === 'Upcoming' || pr.status === 'Active') {
     throw new BadRequestError(
-      'Grading is only available while the peer review is Active'
+      'Grading is not available until the peer review has closed'
     );
+  }
+
+  // Peer review is Closed — check grading window if dates are set
+  const hasGradingDates = pr.gradingStartDate || pr.gradingEndDate;
+  if (hasGradingDates && pr.computedGradingStatus !== 'InProgress') {
+    throw new BadRequestError('Grading is not currently open');
   }
 };
 

--- a/backend/services/peerReviewGradingTaskService.ts
+++ b/backend/services/peerReviewGradingTaskService.ts
@@ -290,11 +290,6 @@ export const bulkAssignGradersByAssessmentId = async (
     assignments.map(a => [String(a._id), String(a.reviewee)])
   );
 
-  // Delete existing grading tasks for this peer review
-  await PeerReviewGradingTaskModel.deleteMany({
-    peerReviewId: peerReview._id,
-  });
-
   // Round-robin assignment with conflict avoidance
   const tasksToCreate: any[] = [];
   let taIndex = 0;
@@ -337,7 +332,10 @@ export const bulkAssignGradersByAssessmentId = async (
       }
 
       if (!candidateTA) {
-        // Could not find enough eligible TAs for this submission
+        // TA-reviewer submissions where the only TA is also the reviewer
+        // cannot be self-assigned — skip them silently.
+        if (submission.reviewerKind === 'TA') break;
+
         throw new BadRequestError(
           `Unable to assign ${numGradersPerSubmission} graders to all submissions with current constraints`
         );
@@ -352,6 +350,11 @@ export const bulkAssignGradersByAssessmentId = async (
       });
     }
   }
+
+  // Only delete existing tasks once new assignment is fully computed (no throw above)
+  await PeerReviewGradingTaskModel.deleteMany({
+    peerReviewId: peerReview._id,
+  });
 
   // Bulk insert new tasks
   await PeerReviewGradingTaskModel.insertMany(tasksToCreate);

--- a/backend/test/services/peerReviewGradingTaskService.test.ts
+++ b/backend/test/services/peerReviewGradingTaskService.test.ts
@@ -584,6 +584,7 @@ describe('peerReviewGradingTaskService', () => {
     );
     expect(constrained.assignedCount).toBeGreaterThan(0);
 
+    // Solo TA who is also the reviewer: their submission is skipped silently (not thrown)
     const soloCourse = await makeCourse({ TAs: [ta1._id] });
     const soloSet = await makeTeamSet(soloCourse._id);
     const soloAssessment = await makeAssessment(soloCourse._id, soloSet._id);
@@ -596,9 +597,14 @@ describe('peerReviewGradingTaskService', () => {
       status: 'Submitted',
     });
 
-    await expect(
-      bulkAssignGradersByAssessmentId(soloCourse._id.toString(), soloAssessment._id.toString(), 1, false)
-    ).rejects.toBeInstanceOf(BadRequestError);
+    const soloResult = await bulkAssignGradersByAssessmentId(
+      soloCourse._id.toString(),
+      soloAssessment._id.toString(),
+      1,
+      false
+    );
+    expect(soloResult.submissionsCount).toBe(1);
+    expect(soloResult.assignedCount).toBe(0); // TA submission skipped — self-reviewer
   });
 
   it('covers manual assignment edge branches', async () => {
@@ -682,9 +688,13 @@ describe('peerReviewGradingTaskService', () => {
         }) as any) as any
     );
 
-    await expect(
-      bulkAssignGradersByAssessmentId(course._id.toString(), assessment._id.toString(), 2, false)
-    ).rejects.toBeInstanceOf(BadRequestError);
+    // TA submission: ta2=self-reviewer blocked, ta3=supervisor blocked (mocked), ta1=eligible for slot 1
+    // Slot 2 can't be filled → TA submission breaks with partial assignment (not a throw)
+    const partialResult = await bulkAssignGradersByAssessmentId(
+      course._id.toString(), assessment._id.toString(), 2, false
+    );
+    expect(partialResult.submissionsCount).toBe(1);
+    expect(partialResult.assignedCount).toBe(1);
     teamFindSpy.mockRestore();
 
     const courseDeleted = await makeCourse({ TAs: [ta1._id] });
@@ -720,6 +730,93 @@ describe('peerReviewGradingTaskService', () => {
     await expect(
       bulkAssignGradersByAssessmentId(courseUnset._id.toString(), assessmentUnset._id.toString(), 1, true)
     ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it('throws when all TAs are ineligible for a student submission due to supervisor constraint', async () => {
+    const ta = await makeUser('constrained-ta');
+    const course = await makeCourse({ TAs: [ta._id] });
+    const ts = await makeTeamSet(course._id);
+    const assessment = await makeAssessment(course._id, ts._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+
+    // TA supervises the reviewee team — blocked when allowSupervisingTAs = false
+    const revieweeTeam = await makeTeam(ts._id, { TA: ta._id });
+    const assignment = await makeAssignment(pr._id, revieweeTeam._id);
+    await makeSubmission(pr._id, assignment._id, {
+      reviewerKind: 'Student',
+      reviewerUserId: oid(),
+      status: 'Submitted',
+    });
+
+    await expect(
+      bulkAssignGradersByAssessmentId(course._id.toString(), assessment._id.toString(), 1, false)
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it('solo TA assigned to supervising team can still grade student submission when allowSupervisingTAs is true', async () => {
+    const ta = await makeUser('solo-ta-supervisor');
+    const course = await makeCourse({ TAs: [ta._id] });
+    const ts = await makeTeamSet(course._id);
+    const assessment = await makeAssessment(course._id, ts._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+
+    // TA supervises the reviewee team
+    const revieweeTeam = await makeTeam(ts._id, { TA: ta._id });
+    const assignment = await makeAssignment(pr._id, revieweeTeam._id);
+    await makeSubmission(pr._id, assignment._id, {
+      reviewerKind: 'Student',
+      reviewerUserId: oid(),
+      status: 'Submitted',
+    });
+
+    const result = await bulkAssignGradersByAssessmentId(
+      course._id.toString(),
+      assessment._id.toString(),
+      1,
+      true // allow same TA
+    );
+
+    expect(result.submissionsCount).toBe(1);
+    expect(result.assignedCount).toBe(1);
+
+    const tasks = await PeerReviewGradingTaskModel.find({ peerReviewId: pr._id }).lean();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].grader.toString()).toBe(ta._id.toString());
+  });
+
+  it('preserves existing grading tasks when bulk assignment computation fails', async () => {
+    const ta = await makeUser('preserve-ta');
+    const course = await makeCourse({ TAs: [ta._id] });
+    const ts = await makeTeamSet(course._id);
+    const assessment = await makeAssessment(course._id, ts._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+
+    const revieweeTeam = await makeTeam(ts._id);
+    const assignment = await makeAssignment(pr._id, revieweeTeam._id);
+    const submission = await makeSubmission(pr._id, assignment._id, {
+      reviewerKind: 'Student',
+      reviewerUserId: oid(),
+      status: 'Submitted',
+    });
+
+    // Pre-existing grading task
+    const existingTask = await new PeerReviewGradingTaskModel({
+      peerReviewId: pr._id,
+      peerReviewSubmissionId: submission._id,
+      grader: ta._id,
+      status: 'Completed',
+      score: 9,
+    }).save();
+
+    // Requesting 2 graders when only 1 TA exists → should throw
+    await expect(
+      bulkAssignGradersByAssessmentId(course._id.toString(), assessment._id.toString(), 2, true)
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    // Existing task must still be intact
+    const remaining = await PeerReviewGradingTaskModel.findById(existingTask._id).lean();
+    expect(remaining).not.toBeNull();
+    expect(remaining!.score).toBe(9);
   });
 
   it('blocks grading updates/submission when linked review submission is not submitted or missing', async () => {

--- a/backend/test/services/peerReviewGradingTaskService.test.ts
+++ b/backend/test/services/peerReviewGradingTaskService.test.ts
@@ -177,7 +177,7 @@ describe('peerReviewGradingTaskService', () => {
     const course = await makeCourse();
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
-    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
 
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
@@ -203,10 +203,27 @@ describe('peerReviewGradingTaskService', () => {
     const course = await makeCourse();
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
-    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
     const submission = await makeSubmission(pr._id, assignment._id, { status: 'Draft' });
+
+    await expect(
+      startGradingTaskForFacultyById(oid().toString(), assessment._id.toString(), submission._id.toString())
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it('startGradingTaskForFacultyById rejects when closed review grading window is not open', async () => {
+    const course = await makeCourse();
+    const ts = await makeTeamSet(course._id);
+    const assessment = await makeAssessment(course._id, ts._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, {
+      status: 'Closed',
+      gradingStartDate: new Date(Date.now() + 60_000),
+    });
+    const reviewee = await makeTeam(ts._id);
+    const assignment = await makeAssignment(pr._id, reviewee._id);
+    const submission = await makeSubmission(pr._id, assignment._id, { status: 'Submitted' });
 
     await expect(
       startGradingTaskForFacultyById(oid().toString(), assessment._id.toString(), submission._id.toString())
@@ -238,7 +255,7 @@ describe('peerReviewGradingTaskService', () => {
     const course = await makeCourse();
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
-    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
     const submission = await makeSubmission(pr._id, assignment._id, { status: 'Submitted' });
@@ -274,7 +291,7 @@ describe('peerReviewGradingTaskService', () => {
     const course = await makeCourse();
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
-    const pr = await makePeerReview(course._id, ts._id, assessment._id);
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
     const submission = await makeSubmission(pr._id, assignment._id, { status: 'Submitted' });
@@ -402,7 +419,7 @@ describe('peerReviewGradingTaskService', () => {
       startGradingTaskForFacultyById(user._id.toString(), assessment._id.toString(), oid().toString())
     ).rejects.toBeInstanceOf(NotFoundError);
 
-    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Upcoming' });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
     const submission = await makeSubmission(pr._id, assignment._id, { status: 'Submitted' });
@@ -413,7 +430,7 @@ describe('peerReviewGradingTaskService', () => {
 
     await expect(
       startGradingTaskForFacultyById(user._id.toString(), assessment._id.toString(), submission._id.toString())
-    ).rejects.toBeInstanceOf(BadRequestError);
+    ).rejects.toBeInstanceOf(BadRequestError); // Upcoming → grading not yet available
 
     const assessment2 = await makeAssessment(course._id, ts._id);
     await makePeerReview(course._id, ts._id, assessment2._id);
@@ -422,7 +439,9 @@ describe('peerReviewGradingTaskService', () => {
     ).rejects.toBeInstanceOf(BadRequestError);
 
     const activeAssessment = await makeAssessment(course._id, ts._id);
-    const activePr = await makePeerReview(course._id, ts._id, activeAssessment._id);
+    const activePr = await makePeerReview(course._id, ts._id, activeAssessment._id, {
+      status: 'Closed',
+    });
     const activeAssignment = await makeAssignment(activePr._id, reviewee._id);
     const activeSubmission = await makeSubmission(activePr._id, activeAssignment._id, { status: 'Submitted' });
 
@@ -472,12 +491,12 @@ describe('peerReviewGradingTaskService', () => {
     const course = await makeCourse();
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
-    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Closed' });
+    const pr = await makePeerReview(course._id, ts._id, assessment._id, { status: 'Upcoming' });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);
     const submission = await makeSubmission(pr._id, assignment._id, { status: 'Submitted' });
 
-    const closedTask = await new PeerReviewGradingTaskModel({
+    const upcomingTask = await new PeerReviewGradingTaskModel({
       peerReviewId: pr._id,
       peerReviewSubmissionId: submission._id,
       grader: grader._id,
@@ -485,14 +504,14 @@ describe('peerReviewGradingTaskService', () => {
     }).save();
 
     await expect(
-      updateGradingTaskById(grader._id.toString(), closedTask._id.toString(), { score: 1 })
-    ).rejects.toBeInstanceOf(BadRequestError);
+      updateGradingTaskById(grader._id.toString(), upcomingTask._id.toString(), { score: 1 })
+    ).rejects.toBeInstanceOf(BadRequestError); // Upcoming → grading not yet available
     await expect(
-      submitGradingTaskById(grader._id.toString(), closedTask._id.toString())
+      submitGradingTaskById(grader._id.toString(), upcomingTask._id.toString())
     ).rejects.toBeInstanceOf(BadRequestError);
 
     const assessment2 = await makeAssessment(course._id, ts._id);
-    const pr2 = await makePeerReview(course._id, ts._id, assessment2._id);
+    const pr2 = await makePeerReview(course._id, ts._id, assessment2._id, { status: 'Closed' });
     const assignment2 = await makeAssignment(pr2._id, reviewee._id);
     const submission2 = await makeSubmission(pr2._id, assignment2._id, { status: 'Submitted' });
 
@@ -825,7 +844,7 @@ describe('peerReviewGradingTaskService', () => {
     const ts = await makeTeamSet(course._id);
     const assessment = await makeAssessment(course._id, ts._id);
     const pr = await makePeerReview(course._id, ts._id, assessment._id, {
-      status: 'Active',
+      status: 'Closed',
     });
     const reviewee = await makeTeam(ts._id);
     const assignment = await makeAssignment(pr._id, reviewee._id);


### PR DESCRIPTION
## Description

This addresses the bug where grading tasks are deleted preemptively before all constraint checks are done. This also addresses the case where if there is only 1 TA in the course and that TA has a submission to be assigned a grader, their submission is silently skipped while all student submissions are assigned that TA (if same TA is allowed). Grading status checks are also updated to enforce when grading is permitted: only after review period is closed and if grading start and end dates are provided, respective constraints are adhered.

## Changes

- Updated peer review grading task service and corresponding test file

Resolves #508 