### PR TITLE
Update Peer Review Settings and Grading Windows

### DIFF
--- a/backend/services/peerReviewAssessmentService.ts
+++ b/backend/services/peerReviewAssessmentService.ts
@@ -271,7 +271,7 @@ export const getPeerReviewSubmissionsForAssessmentById = async (
   const peerReview = await PeerReviewModel.findOne({
     internalAssessmentId: assessmentId,
   }).select(
-    '_id reviewerType taAssignments internalAssessmentId startDate endDate status'
+    '_id reviewerType taAssignments internalAssessmentId startDate endDate gradingStartDate gradingEndDate status'
   );
   if (!peerReview)
     throw new NotFoundError('Peer review not found for assessment');
@@ -279,6 +279,17 @@ export const getPeerReviewSubmissionsForAssessmentById = async (
     | 'Upcoming'
     | 'Active'
     | 'Closed';
+
+  // Mirror assertPeerReviewActive Option B: no grading dates + Closed = open
+  const hasGradingDates =
+    peerReview.gradingStartDate || peerReview.gradingEndDate;
+  const gradingStatus: 'NotStarted' | 'InProgress' | 'Completed' =
+    peerReviewStatus === 'Closed' && !hasGradingDates
+      ? 'InProgress'
+      : ((peerReview.computedGradingStatus ?? 'NotStarted') as
+          | 'NotStarted'
+          | 'InProgress'
+          | 'Completed');
 
   let allowedSubmissionIds: Types.ObjectId[] | null = null;
   if (userCourseRole === COURSE_ROLE.TA) {
@@ -308,6 +319,7 @@ export const getPeerReviewSubmissionsForAssessmentById = async (
       internalAssessmentId: String(assessment._id),
       peerReviewId: String(peerReview._id),
       peerReviewStatus,
+      gradingStatus,
       reviewerType: peerReview.reviewerType,
       taAssignments: peerReview.taAssignments,
       maxMarks: assessment.maxMarks ?? 0,
@@ -504,6 +516,7 @@ export const getPeerReviewSubmissionsForAssessmentById = async (
     internalAssessmentId: String(assessment._id),
     peerReviewId: String(peerReview._id),
     peerReviewStatus,
+    gradingStatus,
     reviewerType: peerReview.reviewerType,
     taAssignments: peerReview.taAssignments,
     maxMarks: assessment.maxMarks ?? 0,

--- a/backend/services/peerReviewService.ts
+++ b/backend/services/peerReviewService.ts
@@ -451,6 +451,27 @@ export const updatePeerReviewById = async (
   const pr = await PeerReviewModel.findById(peerReviewId);
   if (!pr) throw new NotFoundError('Peer review not found');
 
+  // Block structural changes once the review has started
+  if (pr.status !== 'Upcoming') {
+    const attemptingStructuralChange =
+      (settingsData.teamSetId !== undefined &&
+        String(pr.teamSetId) !== String(settingsData.teamSetId)) ||
+      (settingsData.reviewerType !== undefined &&
+        pr.reviewerType !== settingsData.reviewerType) ||
+      (settingsData.taAssignments !== undefined &&
+        pr.taAssignments !== settingsData.taAssignments) ||
+      (settingsData.maxReviews !== undefined &&
+        pr.maxReviewsPerReviewer !== Number(settingsData.maxReviews)) ||
+      (settingsData.commitOrTag !== undefined &&
+        (pr.commitOrTag ?? '') !== (settingsData.commitOrTag ?? ''));
+
+    if (attemptingStructuralChange) {
+      throw new BadRequestError(
+        'Structural settings cannot be changed once the peer review has started'
+      );
+    }
+  }
+
   // Determine if assignment structure should be reset BEFORE save()
   const structuralChanged =
     (settingsData.teamSetId !== undefined &&

--- a/backend/services/peerReviewService.ts
+++ b/backend/services/peerReviewService.ts
@@ -460,7 +460,9 @@ export const updatePeerReviewById = async (
     (settingsData.taAssignments !== undefined &&
       pr.taAssignments !== settingsData.taAssignments) ||
     (settingsData.maxReviews !== undefined &&
-      pr.maxReviewsPerReviewer !== Number(settingsData.maxReviews));
+      pr.maxReviewsPerReviewer !== Number(settingsData.maxReviews)) ||
+    (settingsData.commitOrTag !== undefined &&
+      (pr.commitOrTag ?? '') !== (settingsData.commitOrTag ?? ''));
 
   // map request -> model fields
   if (settingsData.assessmentName !== undefined)

--- a/backend/test/services/peerReviewService.test.ts
+++ b/backend/test/services/peerReviewService.test.ts
@@ -751,6 +751,15 @@ describe('peerReviewService', () => {
       ).rejects.toBeInstanceOf(BadRequestError);
     });
 
+    it('throws BadRequestError when teamSetId is changed on an Active peer review', async () => {
+      const pr = await makePeerReview();
+      const differentTeamSetId = oidStr();
+
+      await expect(
+        updatePeerReviewById(pr._id.toString(), { teamSetId: differentTeamSetId } as any)
+      ).rejects.toBeInstanceOf(BadRequestError);
+    });
+
     it('throws BadRequestError when structural fields are changed on a Closed peer review', async () => {
       const now = Date.now();
       const pr = await makePeerReview({

--- a/backend/test/services/peerReviewService.test.ts
+++ b/backend/test/services/peerReviewService.test.ts
@@ -737,23 +737,56 @@ describe('peerReviewService', () => {
       ).rejects.toBeInstanceOf(NotFoundError);
     });
 
-    it('updates commitOrTag field', async () => {
-      const pr = await makePeerReview({
-        commitOrTag: undefined,
-      });
+    it('resets assignments when commitOrTag changes', async () => {
+      const pr = await makePeerReview({ commitOrTag: undefined });
 
       const updated = await updatePeerReviewById(pr._id.toString(), {
         commitOrTag: 'v1.0.0',
       } as any);
 
       expect(updated.commitOrTag).toBe('v1.0.0');
+      expect(deleteAssignmentsByPeerReviewId).toHaveBeenCalledWith(
+        pr._id.toString()
+      );
+      expect(initialiseAssignments).toHaveBeenCalledWith(
+        testCourseId.toString(),
+        pr._id.toString(),
+        pr.teamSetId.toString(),
+        null,
+        'v1.0.0'
+      );
+    });
 
-      // Also test clearing it
+    it('does not reset assignments when commitOrTag is unchanged', async () => {
+      const pr = await makePeerReview({ commitOrTag: 'v1.0.0' });
+
+      const updated = await updatePeerReviewById(pr._id.toString(), {
+        commitOrTag: 'v1.0.0',
+      } as any);
+
+      expect(updated.commitOrTag).toBe('v1.0.0');
+      expect(deleteAssignmentsByPeerReviewId).not.toHaveBeenCalled();
+      expect(initialiseAssignments).not.toHaveBeenCalled();
+    });
+
+    it('resets assignments when commitOrTag is cleared', async () => {
+      const pr = await makePeerReview({ commitOrTag: 'v1.0.0' });
+
       const cleared = await updatePeerReviewById(pr._id.toString(), {
         commitOrTag: '',
       } as any);
 
       expect(cleared.commitOrTag).toBeUndefined();
+      expect(deleteAssignmentsByPeerReviewId).toHaveBeenCalledWith(
+        pr._id.toString()
+      );
+      expect(initialiseAssignments).toHaveBeenCalledWith(
+        testCourseId.toString(),
+        pr._id.toString(),
+        pr.teamSetId.toString(),
+        null,
+        undefined
+      );
     });
   });
 

--- a/backend/test/services/peerReviewService.test.ts
+++ b/backend/test/services/peerReviewService.test.ts
@@ -622,9 +622,12 @@ describe('peerReviewService', () => {
 
   describe('updatePeerReviewById', () => {
     it('updates peer review and reinitialises assignments when teamSetId provided', async () => {
+      const now = Date.now();
       const pr = await makePeerReview({
         title: 'Old',
         teamSetId: testTeamSetId,
+        startDate: new Date(now + 60_000),
+        endDate: new Date(now + 120_000),
       });
 
       const updated = await updatePeerReviewById(pr._id.toString(), {
@@ -668,10 +671,13 @@ describe('peerReviewService', () => {
     });
 
     it('updates description, review window, reviewerType and review limits', async () => {
+      const now = Date.now();
       const pr = await makePeerReview({
         description: 'old description',
         reviewerType: 'Individual',
         maxReviewsPerReviewer: 2,
+        startDate: new Date(now + 60_000),
+        endDate: new Date(now + 120_000),
       });
 
       const newStart = new Date('2026-04-01T00:00:00.000Z');
@@ -737,8 +743,45 @@ describe('peerReviewService', () => {
       ).rejects.toBeInstanceOf(NotFoundError);
     });
 
+    it('throws BadRequestError when structural fields are changed on an Active peer review', async () => {
+      const pr = await makePeerReview({ reviewerType: 'Individual' }); // default is Active
+
+      await expect(
+        updatePeerReviewById(pr._id.toString(), { reviewerType: 'Team' } as any)
+      ).rejects.toBeInstanceOf(BadRequestError);
+    });
+
+    it('throws BadRequestError when structural fields are changed on a Closed peer review', async () => {
+      const now = Date.now();
+      const pr = await makePeerReview({
+        startDate: new Date(now - 120_000),
+        endDate: new Date(now - 60_000),
+        maxReviewsPerReviewer: 2,
+      });
+
+      await expect(
+        updatePeerReviewById(pr._id.toString(), { maxReviews: 3 } as any)
+      ).rejects.toBeInstanceOf(BadRequestError);
+    });
+
+    it('allows non-structural field changes on an Active peer review', async () => {
+      const pr = await makePeerReview({ title: 'Old' }); // default is Active
+
+      const updated = await updatePeerReviewById(pr._id.toString(), {
+        assessmentName: 'New Title',
+      } as any);
+
+      expect(updated.title).toBe('New Title');
+      expect(deleteAssignmentsByPeerReviewId).not.toHaveBeenCalled();
+    });
+
     it('resets assignments when commitOrTag changes', async () => {
-      const pr = await makePeerReview({ commitOrTag: undefined });
+      const now = Date.now();
+      const pr = await makePeerReview({
+        commitOrTag: undefined,
+        startDate: new Date(now + 60_000),
+        endDate: new Date(now + 120_000),
+      });
 
       const updated = await updatePeerReviewById(pr._id.toString(), {
         commitOrTag: 'v1.0.0',
@@ -770,7 +813,12 @@ describe('peerReviewService', () => {
     });
 
     it('resets assignments when commitOrTag is cleared', async () => {
-      const pr = await makePeerReview({ commitOrTag: 'v1.0.0' });
+      const now = Date.now();
+      const pr = await makePeerReview({
+        commitOrTag: 'v1.0.0',
+        startDate: new Date(now + 60_000),
+        endDate: new Date(now + 120_000),
+      });
 
       const cleared = await updatePeerReviewById(pr._id.toString(), {
         commitOrTag: '',

--- a/multi-git-dashboard/src/components/cards/PeerReviewSubmissionCard.tsx
+++ b/multi-git-dashboard/src/components/cards/PeerReviewSubmissionCard.tsx
@@ -42,6 +42,7 @@ interface PeerReviewSubmissionCardProps {
   courseId: string;
   assessmentId: string;
   peerReviewStatus: 'Upcoming' | 'Active' | 'Closed';
+  gradingStatus: 'NotStarted' | 'InProgress' | 'Completed';
   userId: string;
   item: PeerReviewSubmissionListItemDTO;
   isFaculty: boolean;
@@ -52,6 +53,7 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
   courseId,
   assessmentId,
   peerReviewStatus,
+  gradingStatus,
   userId,
   item,
   isFaculty,
@@ -73,8 +75,8 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
   const [loadingTAs, setLoadingTAs] = useState(false);
 
   const isSubmissionSubmitted = item.status === 'Submitted';
-  const isPeerReviewActive = peerReviewStatus === 'Active';
   const isPeerReviewClosed = peerReviewStatus === 'Closed';
+  const isGradingOpen = isPeerReviewClosed && gradingStatus === 'InProgress';
   const myGrader = item.grading.graders.find(g => g.id === userId);
   const isMyGradingInProgress = myGrader?.status === 'InProgress';
   const isMyGradingCompleted = myGrader?.status === 'Completed';
@@ -85,8 +87,8 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
   let buttonIcon: JSX.Element;
   let buttonText: string;
 
-  if (!isPeerReviewActive || !isSubmissionSubmitted) {
-    // Not submitted - both Faculty and TAs can only view
+  if (!isGradingOpen || !isSubmissionSubmitted) {
+    // Grading not open or submission not ready — view only
     buttonColor = 'blue';
     buttonIcon = <IconEye size={16} />;
     buttonText = 'View';
@@ -310,7 +312,7 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
                         size="xs"
                         color="red"
                         variant="subtle"
-                        disabled={isPeerReviewClosed}
+                        disabled={!isPeerReviewClosed || gradingStatus === 'Completed'}
                         onClick={() => handleUnassignGrader(grader.id)}
                         loading={unassigningGrader === grader.id}
                       >
@@ -346,7 +348,7 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
                 variant="subtle"
                 size="sm"
                 leftSection={<IconUserPlus size={16} />}
-                disabled={isPeerReviewClosed}
+                disabled={!isPeerReviewClosed || gradingStatus === 'Completed'}
                 loading={assigningGrader || loadingTAs}
               >
                 Assign Grader

--- a/multi-git-dashboard/src/components/cards/PeerReviewSubmissionCard.tsx
+++ b/multi-git-dashboard/src/components/cards/PeerReviewSubmissionCard.tsx
@@ -312,7 +312,9 @@ const PeerReviewSubmissionCard: React.FC<PeerReviewSubmissionCardProps> = ({
                         size="xs"
                         color="red"
                         variant="subtle"
-                        disabled={!isPeerReviewClosed || gradingStatus === 'Completed'}
+                        disabled={
+                          !isPeerReviewClosed || gradingStatus === 'Completed'
+                        }
                         onClick={() => handleUnassignGrader(grader.id)}
                         loading={unassigningGrader === grader.id}
                       >

--- a/multi-git-dashboard/src/components/forms/PeerReviewBaseForm.tsx
+++ b/multi-git-dashboard/src/components/forms/PeerReviewBaseForm.tsx
@@ -194,7 +194,10 @@ const PeerReviewBaseForm: React.FC<PeerReviewBaseFormProps> = ({
         color: 'green',
       });
     } catch (e) {
-      setError((e as Error).message || 'Something went wrong');
+      const msg = (e as Error).message || '';
+      if (msg !== '__SUBMIT_INTERCEPTED__') {
+        setError(msg || 'Something went wrong');
+      }
     } finally {
       setLoading(false);
     }
@@ -242,7 +245,6 @@ const PeerReviewBaseForm: React.FC<PeerReviewBaseFormProps> = ({
           label="Start Date"
           {...form.getInputProps('startDate')}
           type="date"
-          disabled={lockReviewConfig}
           mb="xs"
         />
         <TextInput
@@ -260,6 +262,7 @@ const PeerReviewBaseForm: React.FC<PeerReviewBaseFormProps> = ({
           placeholder="e.g., v1.0, main, abc123"
           description="Specify a commit hash or tag to use for reviews. Leave empty to use the latest version."
           {...form.getInputProps('commitOrTag')}
+          disabled={lockReviewConfig}
         />
 
         <Text fw={600} fz="sm" mt="md" mb="xs">
@@ -285,11 +288,14 @@ const PeerReviewBaseForm: React.FC<PeerReviewBaseFormProps> = ({
             form.setFieldValue('reviewerType', value as ReviewerType)
           }
           ml="4px"
-          readOnly={lockReviewConfig}
         >
           <Group>
-            <Radio label="Team" value="Team" />
-            <Radio label="Individual" value="Individual" />
+            <Radio label="Team" value="Team" disabled={lockReviewConfig} />
+            <Radio
+              label="Individual"
+              value="Individual"
+              disabled={lockReviewConfig}
+            />
           </Group>
         </Radio.Group>
 
@@ -300,11 +306,10 @@ const PeerReviewBaseForm: React.FC<PeerReviewBaseFormProps> = ({
           value={form.values.taAssignments ? 'yes' : 'no'}
           onChange={val => form.setFieldValue('taAssignments', val === 'yes')}
           ml="4px"
-          readOnly={lockReviewConfig}
         >
           <Group gap="28px">
-            <Radio label="Yes" value="yes" />
-            <Radio label="No" value="no" />
+            <Radio label="Yes" value="yes" disabled={lockReviewConfig} />
+            <Radio label="No" value="no" disabled={lockReviewConfig} />
           </Group>
         </Radio.Group>
 

--- a/multi-git-dashboard/src/components/forms/UpdatePeerReviewForm.tsx
+++ b/multi-git-dashboard/src/components/forms/UpdatePeerReviewForm.tsx
@@ -1,4 +1,7 @@
 // UpdatePeerReviewAssessmentForm.tsx
+import { useState, useRef } from 'react';
+import { Button, Group, Modal, Text } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import PeerReviewBaseForm, {
   NormalizedPeerReviewBasePayload,
   PeerReviewBaseFormValues,
@@ -48,6 +51,16 @@ function toInitialValues(
   };
 }
 
+const hasStructuralChanges = (
+  peerReview: PeerReview,
+  payload: NormalizedPeerReviewBasePayload
+): boolean =>
+  String(peerReview.teamSetId) !== String(payload.teamSetId) ||
+  peerReview.reviewerType !== payload.reviewerType ||
+  Boolean(peerReview.taAssignments) !== payload.taAssignments ||
+  (peerReview.maxReviewsPerReviewer ?? 1) !== payload.maxReviews ||
+  (peerReview.commitOrTag ?? '') !== (payload.commitOrTag ?? '');
+
 const UpdatePeerReviewForm: React.FC<UpdatePeerReviewFormProps> = ({
   courseId,
   teamSets,
@@ -57,7 +70,10 @@ const UpdatePeerReviewForm: React.FC<UpdatePeerReviewFormProps> = ({
   onUpdated,
   onClose,
 }) => {
-  const submit = async (payload: NormalizedPeerReviewBasePayload) => {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const pendingPayload = useRef<NormalizedPeerReviewBasePayload | null>(null);
+
+  const performSubmit = async (payload: NormalizedPeerReviewBasePayload) => {
     const res = await fetch(
       `/api/peer-review-assessments/${courseId}/${internalAssessment._id}/peer-review`,
       {
@@ -74,17 +90,65 @@ const UpdatePeerReviewForm: React.FC<UpdatePeerReviewFormProps> = ({
     onClose?.();
   };
 
+  const handleSubmit = async (payload: NormalizedPeerReviewBasePayload) => {
+    if (!lockReviewConfig && hasStructuralChanges(peerReview, payload)) {
+      pendingPayload.current = payload;
+      setConfirmOpen(true);
+      throw new Error('__SUBMIT_INTERCEPTED__');
+    }
+    await performSubmit(payload);
+  };
+
+  const handleConfirm = async () => {
+    setConfirmOpen(false);
+    if (pendingPayload.current) {
+      await performSubmit(pendingPayload.current);
+      pendingPayload.current = null;
+      notifications.show({
+        title: 'Peer Review Updated',
+        message: 'Updated successfully.',
+        color: 'green',
+      });
+    }
+  };
+
   return (
-    <PeerReviewBaseForm
-      courseId={courseId}
-      teamSets={teamSets}
-      mode="update"
-      initialValues={toInitialValues(peerReview, internalAssessment)}
-      lockReviewConfig={lockReviewConfig}
-      submitLabel="Update Peer Review"
-      onCancel={onClose}
-      onSubmit={submit}
-    />
+    <>
+      <PeerReviewBaseForm
+        courseId={courseId}
+        teamSets={teamSets}
+        mode="update"
+        initialValues={toInitialValues(peerReview, internalAssessment)}
+        lockReviewConfig={lockReviewConfig}
+        submitLabel="Update Peer Review"
+        onCancel={onClose}
+        onSubmit={handleSubmit}
+      />
+
+      <Modal
+        opened={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        title="Reset Assignments?"
+        centered
+        size="sm"
+      >
+        <Text fz="sm" mb="lg">
+          You have changed one or more structural settings (team set, reviewer
+          type, TA assignments, max reviews, or commit/tag).
+          <br />
+          <br />
+          Saving will <strong>delete all existing assignments</strong>.
+        </Text>
+        <Group justify="flex-end" gap="sm">
+          <Button color="orange" onClick={handleConfirm}>
+            Reset & Save
+          </Button>
+          <Button variant="default" onClick={() => setConfirmOpen(false)}>
+            Cancel
+          </Button>
+        </Group>
+      </Modal>
+    </>
   );
 };
 

--- a/multi-git-dashboard/src/components/views/PeerReviewAssessmentOverview.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewAssessmentOverview.tsx
@@ -197,10 +197,12 @@ const PeerReviewAssessmentOverview: React.FC<
     'Unknown Team Set';
 
   const now = new Date();
+  const reviewStartAt = new Date(peerReview.startDate);
   const reviewEndAt = new Date(peerReview.endDate);
   const assessmentEndAt = assessment.endDate
     ? new Date(assessment.endDate)
     : null;
+  const isReviewStarted = now >= reviewStartAt;
   const isReviewClosed = now > reviewEndAt;
   const isAssessmentClosed = !!(assessmentEndAt && now >= assessmentEndAt);
   const isGradingPhase = isReviewClosed && !isAssessmentClosed;
@@ -259,7 +261,7 @@ const PeerReviewAssessmentOverview: React.FC<
           teamSets={teamSets}
           peerReview={peerReview}
           internalAssessment={assessment}
-          lockReviewConfig={isReviewClosed}
+          lockReviewConfig={isReviewStarted}
           onUpdated={() => {
             closeUpdateModal();
             fetchData();

--- a/multi-git-dashboard/src/components/views/PeerReviewSubmissions.tsx
+++ b/multi-git-dashboard/src/components/views/PeerReviewSubmissions.tsx
@@ -402,6 +402,7 @@ const PeerReviewSubmissions: React.FC<PeerReviewSubmissionsProps> = ({
                     userId={me.userId}
                     assessmentId={assessmentId}
                     peerReviewStatus={dto.peerReviewStatus}
+                    gradingStatus={dto.gradingStatus}
                     item={item}
                     isFaculty={isFaculty}
                     onAfterAction={fetchSubmissions}

--- a/shared/types/PeerReviewAssessment.ts
+++ b/shared/types/PeerReviewAssessment.ts
@@ -44,7 +44,8 @@ export interface PeerReviewSubmissionsDTO {
   internalAssessmentId: string;
   peerReviewId: string;
   peerReviewStatus: 'Upcoming' | 'Active' | 'Closed';
-  
+  gradingStatus: 'NotStarted' | 'InProgress' | 'Completed';
+
   reviewerType: ReviewerType;
   taAssignments: boolean;
   maxMarks: number;


### PR DESCRIPTION
## Description

- Structural fields like commitOrTag, maxReviewsPerReviewer, reviewerType, taAssignments should not be editable once the peer review period becomes active. This serves as a form of mitigation to clean-state regeneration.
- Submissions can only start to be graded once peer review period is closed and grading window is open.

## Changes

- When peer review upcoming, structural fields can be updated. A confirmation modal indicating resetting assignments will be shown to coordinators.
- When peer review is active/closed, these fields are disabled for editing.
- Updated to ensure grading windows adhered, and grading only starts after peer review period is closed.